### PR TITLE
Improvements/ramp p2p

### DIFF
--- a/rampp2p/models/payment.py
+++ b/rampp2p/models/payment.py
@@ -36,11 +36,3 @@ class PaymentMethod(models.Model):
 
   def __str__(self):
     return f"{self.id}"
-  
-  def delete(self, *args, **kwargs):
-    # disable deleting of payment method if it is used by any Ad
-    Ad = apps.get_model('rampp2p', 'Ad')
-    ads_using_this = Ad.objects.filter(deleted_at__isnull=True, payment_methods__id=self.id)
-    if ads_using_this.exists():
-      raise ValidationError("Cannot delete Payment Method while it is used by an Ad")
-    super().delete(*args, **kwargs)

--- a/rampp2p/views/payment.py
+++ b/rampp2p/views/payment.py
@@ -4,10 +4,10 @@ from rest_framework import status
 
 from django.http import Http404
 from django.core.exceptions import ValidationError
-
 from authentication.token import TokenAuthentication
-
-from rampp2p.models import PaymentType, PaymentMethod, Peer, IdentifierFormat, FiatCurrency
+from django.db.models import OuterRef, Subquery
+# from rampp2p.models import PaymentType, PaymentMethod, Peer, IdentifierFormat, FiatCurrency
+import rampp2p.models as models
 from rampp2p.serializers import (
     PaymentTypeSerializer, 
     PaymentMethodSerializer,
@@ -22,10 +22,10 @@ class PaymentTypeList(APIView):
     authentication_classes = [TokenAuthentication]
 
     def get(self, request):
-        queryset = PaymentType.objects.all()
+        queryset = models.PaymentType.objects.all()
         currency = request.query_params.get('currency')
         if currency:
-            fiat_currency = FiatCurrency.objects.filter(symbol=currency)
+            fiat_currency = models.FiatCurrency.objects.filter(symbol=currency)
             if not fiat_currency.exists():
                 return Response({'error': f'no such fiat currency with symbol {currency}'}, status.HTTP_400_BAD_REQUEST)
             fiat_currency = fiat_currency.first()
@@ -37,10 +37,10 @@ class PaymentMethodListCreate(APIView):
     authentication_classes = [TokenAuthentication]
 
     def get(self, request):
-        queryset = PaymentMethod.objects.filter(owner__wallet_hash=request.user.wallet_hash)
+        queryset = models.PaymentMethod.objects.filter(owner__wallet_hash=request.user.wallet_hash)
         currency = request.query_params.get('currency')
         if currency:
-            fiat_currency = FiatCurrency.objects.filter(symbol=currency)
+            fiat_currency = models.FiatCurrency.objects.filter(symbol=currency)
             if not fiat_currency.exists():
                 return Response({'error': f'no such fiat currency with symbol {currency}'}, status.HTTP_400_BAD_REQUEST)
             fiat_currency = fiat_currency.first()
@@ -53,7 +53,7 @@ class PaymentMethodListCreate(APIView):
         data = request.data.copy()
         data['owner'] = request.user.id
 
-        format = IdentifierFormat.objects.filter(format=data.get('identifier_format'))
+        format = models.IdentifierFormat.objects.filter(format=data.get('identifier_format'))
         if not format.exists():
             return Response({'error': 'identifier_format is required'}, status=status.HTTP_400_BAD_REQUEST)
         
@@ -70,9 +70,9 @@ class PaymentMethodDetail(APIView):
     
     def get_object(self, pk):
         try:
-            payment_method = PaymentMethod.objects.get(pk=pk)
+            payment_method = models.PaymentMethod.objects.get(pk=pk)
             return payment_method
-        except PaymentMethod.DoesNotExist:
+        except models.PaymentMethod.DoesNotExist:
             raise Http404
     
     def get(self, request, pk):
@@ -92,7 +92,7 @@ class PaymentMethodDetail(APIView):
             return Response({'error': err.args[0]}, status=status.HTTP_403_FORBIDDEN)
         
         data = request.data.copy()
-        format = IdentifierFormat.objects.filter(format=data.get('identifier_format'))
+        format = models.IdentifierFormat.objects.filter(format=data.get('identifier_format'))
         if not format.exists():
             return Response({'error': 'identifier_format is required'}, status=status.HTTP_400_BAD_REQUEST)
         
@@ -112,6 +112,23 @@ class PaymentMethodDetail(APIView):
         
         try:
             payment_method = self.get_object(pk=pk)
+            # disable deletion if used by any Ad as payment method
+            ads_using_this = models.Ad.objects.filter(deleted_at__isnull=True, payment_methods__id=payment_method.id)
+            if ads_using_this.exists():
+                raise ValidationError("Unable to delete Ad payment method")
+    
+            # disable deletion if payment method is used by ongoing orders
+            latest_status_subquery = models.Status.objects.filter(
+                order=OuterRef('pk'),
+            ).order_by('-created_at').values('status')[:1]
+            annotated_orders = models.Order.objects.annotate(latest_status = Subquery(latest_status_subquery))
+            completed_status = [models.StatusType.CANCELED, models.StatusType.RELEASED, models.StatusType.REFUNDED]
+            incomplete_orders = annotated_orders.exclude(latest_status__in=completed_status)
+            orders_using_this = incomplete_orders.filter(payment_methods__id=payment_method.id)
+            logger.warn(f'{orders_using_this.count()} orders using this payment method')
+            if orders_using_this.exists():
+                raise ValidationError(f"Unable to delete payment method used by {orders_using_this.count()} ongoing order(s)")
+            
             payment_method.delete()
         except Exception as err:
             return Response({'error': err.args[0]},status=status.HTTP_400_BAD_REQUEST)
@@ -122,9 +139,9 @@ class PaymentMethodDetail(APIView):
         Validates if caller is owner
         '''
         try:
-            payment_method = PaymentMethod.objects.get(pk=id)
-            caller = Peer.objects.get(wallet_hash=wallet_hash)
-        except (PaymentMethod.DoesNotExist, Peer.DoesNotExist) as err:
+            payment_method = models.PaymentMethod.objects.get(pk=id)
+            caller = models.Peer.objects.get(wallet_hash=wallet_hash)
+        except (models.PaymentMethod.DoesNotExist, models.Peer.DoesNotExist) as err:
             raise ValidationError(err.args[0])
         
         if caller.wallet_hash != payment_method.owner.wallet_hash:


### PR DESCRIPTION
- Disable deleting of payment methods used by ongoing orders
- Arbiters will now receive push notifications only from orders with
appeals
- Send a separate message for arbiter chat push notification
- Include `appeal_id` as extra push-notification data sent if order is appealed