### PR TITLE
Improvements/wallet history parser

### DIFF
--- a/main/signals.py
+++ b/main/signals.py
@@ -1,3 +1,4 @@
+import logging
 from django.conf import settings
 from django.db import transaction
 from django.db.models.signals import post_save
@@ -150,4 +151,7 @@ def wallet_history_post_save(sender, instance=None, created=False, **kwargs):
             txid=instance.txid,
             wallet=instance.wallet,
             record_type=instance.record_type,
+            token=instance.token,
+            cashtoken_ft=instance.cashtoken_ft,
+            cashtoken_nft=instance.cashtoken_nft,
         ).exclude(id=instance.id).delete()

--- a/main/utils/push_notification.py
+++ b/main/utils/push_notification.py
@@ -48,7 +48,7 @@ def send_wallet_history_push_notification(wallet_history_obj):
             'message': message,
             'wallet_hash': wallet_history_obj.wallet.wallet_hash,
             'notif_type': 'TR',
-            'extra_data': parse_transaction_extra_data(wallet_history_obj.txid),
+            'extra_data': parse_transaction_extra_data(wallet_history_obj),
             'date_posted': timezone.now().isoformat()
         })
 
@@ -79,7 +79,7 @@ def send_wallet_history_push_notification_nft(wallet_history_obj):
             'message': message,
             'wallet_hash': wallet_history_obj.wallet.wallet_hash,
             'notif_type': 'NF',
-            'extra_data': parse_transaction_extra_data(wallet_history_obj.txid),
+            'extra_data': parse_transaction_extra_data(wallet_history_obj),
             'date_posted': timezone.now().isoformat()
         })
 
@@ -90,6 +90,5 @@ def send_wallet_history_push_notification_nft(wallet_history_obj):
             extra=extra
         )
 
-def parse_transaction_extra_data(txid):
-    wallet_history = WalletHistory.objects.get(txid=txid)
-    return f'{txid};{wallet_history.token.pk}'
+def parse_transaction_extra_data(wallet_history):
+    return f'{wallet_history.txid};{wallet_history.token.pk}'


### PR DESCRIPTION
## Description
- Fixed bug where utxos with FT & NFT are not saved properly in `Transaction` and `WalletHistory`
- Improved wallet history parser to handle transactions with multiple fungible tokens
- Fixed bug where a wallet history with BCH and Fungible token amount only saves the BCH wallet history.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
- Manually tested in chipnet through `api/stablehedge/test-utils/process_tx/`. Tested with following transactions:
  - Multiple FT outputs with 1 output FT/NFT: [d7604defebb1c92e5d5e43aade1a8239fe5ebe8eff5dd459df6d4d2cff1fdebc](https://chipnet.watchtower.cash/api/transactions/d7604defebb1c92e5d5e43aade1a8239fe5ebe8eff5dd459df6d4d2cff1fdebc/)
  - Single FT: [af056ffd9d133174019aa0b76a0e39a49513dbfe0ac9651a840742ba773a0e6a](https://chipnet.watchtower.cash/api/transactions/af056ffd9d133174019aa0b76a0e39a49513dbfe0ac9651a840742ba773a0e6a/)
  - BCH only: [db83408b6a865fd7627ad04aca510d5402b4ab7a696430c0d667fad0672df6b6](https://chipnet.watchtower.cash/api/transactions/db83408b6a865fd7627ad04aca510d5402b4ab7a696430c0d667fad0672df6b6/)
