### PR TITLE
Improvements/p2p exchange

### DIFF
--- a/rampp2p/admin.py
+++ b/rampp2p/admin.py
@@ -190,8 +190,8 @@ class PaymentTypeAdmin(admin.ModelAdmin):
 
 @admin.register(Peer)
 class PeerAdmin(admin.ModelAdmin):
-    list_display = ['name', 'address', 'is_disabled']
-    search_fields = ['name', 'address', 'wallet_hash']
+    list_display = ['id', 'name', 'address', 'is_disabled']
+    search_fields = ['id', 'name', 'address', 'wallet_hash']
 
 @admin.register(Status)
 class StatusAdmin(DynamicRawIDMixin, admin.ModelAdmin):

--- a/rampp2p/utils/utils.py
+++ b/rampp2p/utils/utils.py
@@ -10,6 +10,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 def update_user_active_status(wallet_hash, is_online):
+    if wallet_hash == None: return
+    
     Peer = apps.get_model('rampp2p', 'Peer')
     Arbiter = apps.get_model('rampp2p', 'Arbiter')
     try:

--- a/rampp2p/views/view_appeal.py
+++ b/rampp2p/views/view_appeal.py
@@ -30,6 +30,7 @@ class AppealViewSet(viewsets.GenericViewSet):
         try:
             arbiter = models.Arbiter.objects.get(wallet_hash=wallet_hash)
             appeal_state = request.query_params.get('state')
+            sort_by_date = request.query_params.get('sort_by_date', 'desc')
             limit = int(request.query_params.get('limit', 0))
             page = int(request.query_params.get('page', 1))
 
@@ -40,7 +41,8 @@ class AppealViewSet(viewsets.GenericViewSet):
                 return Response({'error': 'invalid page number'}, status=status.HTTP_400_BAD_REQUEST)
             
             arbiter_order_ids = list(models.Order.objects.filter(arbiter__wallet_hash=arbiter.wallet_hash).values_list('id', flat=True))
-            queryset = models.Appeal.objects.filter(order__pk__in=arbiter_order_ids).order_by('created_at')
+            order_by_key = 'created_at' if sort_by_date == 'asc' else '-created_at'
+            queryset = models.Appeal.objects.filter(order__pk__in=arbiter_order_ids).order_by(order_by_key)
 
             if appeal_state == 'PENDING':
                 queryset = queryset.exclude(resolved_at__isnull=False)

--- a/rampp2p/views/view_user.py
+++ b/rampp2p/views/view_user.py
@@ -342,6 +342,7 @@ class PeerFeedbackViewSet(viewsets.GenericViewSet):
         from_peer = request.query_params.get('from_peer', None)
         to_peer = request.query_params.get('to_peer', None)
         rating = request.query_params.get('rating', None)
+        sort_by_date = request.query_params.get('sort_by_date', 'desc')
 
         try:
             limit = int(request.query_params.get('limit', 0))
@@ -369,6 +370,9 @@ class PeerFeedbackViewSet(viewsets.GenericViewSet):
         
         if rating is not None:
             queryset = queryset.filter(Q(rating=rating))
+
+        order_by_key = 'created_at' if sort_by_date == 'asc' else '-created_at'
+        queryset = queryset.order_by(order_by_key)
 
         # pagination
         count = queryset.count()


### PR DESCRIPTION
## Description
- Enhanced the appeals endpoint to allow sorting by the `created_at` date.
- Fixed an issue that occurred when updating the user's active status with a `wallet_hash` value of None.

## Screenshots (if applicable):
N/A backend changes only

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Test Notes
How Has This Been Tested?

The changes have been tested using manual verification. The following steps were taken:
- Verified the sorting functionality of the appeals list by the `created_at` date.
- Tested the user active status update to confirm the error no longer occurs when `wallet_hash` is None.
