### PR TITLE
Bug fix: empty cash-in ads list when valid ads have fiat trade limits

### DIFF
--- a/rampp2p/models/model_currency.py
+++ b/rampp2p/models/model_currency.py
@@ -40,7 +40,7 @@ class CryptoCurrency(models.Model):
     def get_cashin_presets(self):
         if self.cashin_presets:
             return list(map(int, self.cashin_presets.split(',')))
-        return None
+        return ['0.02', '0.04', '0.1', '0.25', '0.5', '1']
 
     def set_cashin_presets(self, presets):
         self.cashin_presets = ','.join(map(str, presets))

--- a/rampp2p/slackbot/send.py
+++ b/rampp2p/slackbot/send.py
@@ -921,6 +921,6 @@ class AdUpdateMessage(MessageBase):
                 return ""
             return f"{ad.trade_type} ad #{ad.id} updated payment type(s) to {new_payment_types}"
         elif update_type == AdUpdateType.DELETED_AT:
-            return f"{ad.trade_type} d #{ad.id} deleted"
+            return f"{ad.trade_type} ad #{ad.id} deleted"
         else:
             return ""


### PR DESCRIPTION
## Description
- Fixed issue in the endpoint for retrieving cash-in ads by preset where valid ads do not show up as available if their trade limits are set in fiat.
- Fixed typo in Slack ad update message.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test Notes
How Has This Been Tested?

The changes were tested manually:
- Verified that an ad is available for cash-in orders after the owner sets its trade limits in fiat.
- Verified that an ad is available for cash-in orders regardless of whether the ad's trade limit currency is fiat or BCH.

Will the applied changes affect other areas of the code? Will the applied changes affect functionalities of other features? - No. The changes will only affect the cash-in feature.

