### PR TITLE
improvements/jpp fetch

### DIFF
--- a/jpp/parser.py
+++ b/jpp/parser.py
@@ -16,6 +16,12 @@ class BComPaymentParser(parsers.BaseParser):
         # return super().parse(stream, media_type=None, parser_context=None)
         return stream.read()
 
+class BComPaymentRequestParser(parsers.BaseParser):
+    media_type = MediaTypes.BCom.PaymentRequest
+
+class BitPayPaymentOptionsParser(parsers.JSONParser):
+    media_type = MediaTypes.BitPay.PaymentOptions
+
 class BitPayPaymentRequestParser(parsers.JSONParser):
     media_type = MediaTypes.BitPay.PaymentRequest
 


### PR DESCRIPTION
## Description
- Allow invoice detail api to return protobuf or bitpay response based on Accept header. This allows using the same url across different wallet implementation of JPP.

Fixes # (issue)
- Issue with invoice url not being recognized in Bitcoin.com wallet

## Screenshots (if applicable):
n/a


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Tested using `api/jpp/invoices/{uuid}/` as JPP url in payment url in qrcode if works both in paytaca-app and bitcoin.com wallet

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
