### PR TITLE
Improvements

### DIFF
--- a/paytacapos/views.py
+++ b/paytacapos/views.py
@@ -459,8 +459,7 @@ class CashOutViewSet(viewsets.ModelViewSet):
             limit = int(request.query_params.get('limit', 0))
             page = int(request.query_params.get('page', 1))
             merchant_ids = request.query_params.getlist('merchant_ids', [])
-            order_type = request.query_params.get('order_type', 'all')
-            order_type = order_type.upper()
+            order_types = request.query_params.getlist('order_types', [])
 
             if limit < 0:
                 raise ValidationError('limit must be a non-negative number')
@@ -474,9 +473,10 @@ class CashOutViewSet(viewsets.ModelViewSet):
             if len(merchant_ids) > 0:
                 queryset = queryset.filter(merchant__id__in=merchant_ids)
 
-            if order_type != 'ALL':
-                queryset = queryset.filter(status__icontains=order_type).order_by('-created_at')
+            if len(order_types) > 0:
+                queryset = queryset.filter(status__in=order_types)
             
+            queryset = queryset.order_by('-created_at')
             count = queryset.count()
             total_pages = page
             if limit > 0:


### PR DESCRIPTION
## Description
- Changed query parameter for filtering cash out orders by type to accept a list. This allows filtering with multiple order types `(PENDING | PROCESSING | COMPLETED)`

## Screenshots (if applicable):
N/A


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test Notes
How Has This Been Tested?

The changes applied were tested manually. It will not affect other areas or functionalities of other features.

## @mentions
@joemarct 
