### PR TITLE
Fixed 401 error calling payment type with authenticated requests

### DIFF
--- a/authentication/token.py
+++ b/authentication/token.py
@@ -57,6 +57,15 @@ class TokenAuthentication(BaseAuthentication):
         
         return (wallet, None)
 
+class IgnoreInvalidTokenAuthentication(TokenAuthentication):
+    def authenticate(self, request):
+        try:
+            auth = super().authenticate(request)
+            if auth is None:
+                return None
+            return auth
+        except AuthenticationFailed:
+            return None
 
 class WalletAuthentication(BaseAuthentication):
     def get_auth_headers(self, request):

--- a/rampp2p/views/view_payment.py
+++ b/rampp2p/views/view_payment.py
@@ -1,6 +1,7 @@
+
+from rest_framework import status, viewsets
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework import status, viewsets
 from rest_framework.parsers import MultiPartParser
 from rest_framework.decorators import action
 
@@ -9,7 +10,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import OuterRef, Subquery, Q
 from django.utils.translation import gettext_lazy as _
 
-from authentication.token import TokenAuthentication
+from authentication.token import TokenAuthentication, IgnoreInvalidTokenAuthentication
 from authentication.permissions import RampP2PIsAuthenticated
 
 import rampp2p.models as models
@@ -22,6 +23,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 class PaymentTypeView(APIView):
+    authentication_classes = [IgnoreInvalidTokenAuthentication]
+
     def get(self, request):
         queryset = models.PaymentType.objects.filter(payment_currency__isnull=False)
         currency = request.query_params.get('currency')


### PR DESCRIPTION
## Description
- Added a custom class to ignore authentication when handling token authenticated requests to the GET payment type endpoint

Fixes # (issue)
- Fixes payment type related issues in the frontend

## Screenshots (if applicable):
N/A


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
How Has This Been Tested?

The applied change was tested manually. It should not affect other areas of the code nor affect functionalities of other features.

## @mentions
@joemarct 
