### PR TITLE
Improvements/tx address api

### DIFF
--- a/main/filters.py
+++ b/main/filters.py
@@ -281,6 +281,8 @@ class TokensViewSetFilter(BaseFilterBackend):
 
 
 class TransactionOutputFilter(filters.FilterSet):
+    txid = filters.CharFilter()
+    index = filters.NumberFilter()
     address = filters.CharFilter(field_name='address__address')
     token_address = filters.CharFilter(field_name='address__token_address')
     tokenid = filters.CharFilter(field_name='token__tokenid')

--- a/main/views/view_address.py
+++ b/main/views/view_address.py
@@ -2,6 +2,7 @@ from django.db.models import Q
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 from main.models import Address
 from main.serializers import AddressInfoSerializer
@@ -10,13 +11,31 @@ from notifications.models import DeviceWallet
 class AddressInfoView(APIView):
     serializer_class = AddressInfoSerializer
 
-    @swagger_auto_schema(responses={200: AddressInfoSerializer})
+    @swagger_auto_schema(
+        responses={200: AddressInfoSerializer},
+        manual_parameters=[
+            openapi.Parameter('wallet_hash', openapi.IN_QUERY, type=openapi.TYPE_STRING),
+            openapi.Parameter('project_id', openapi.IN_QUERY, type=openapi.TYPE_STRING),
+        ],
+    )
     def get(self, request, *args, **kwargs):
         bchaddress = kwargs.get('bchaddress', '')
 
+        filter_kwargs = {}
+        query_params = request.query_params
+        if "wallet_hash" in query_params:
+            filter_kwargs["wallet__wallet_hash"] = query_params["wallet_hash"]
+
+        if "project_id" in query_params:
+            filter_kwargs["project__id"] = query_params["project_id"]
+
         address_obj = Address.objects.filter(
-            Q(address=bchaddress) | Q(token_address=bchaddress)
+            Q(address=bchaddress) | Q(token_address=bchaddress),
+            **filter_kwargs,
         ).first()
+
+        if not address_obj:
+            return Response()
 
         wallet = getattr(address_obj, "wallet", None)
         wallet_hash = getattr(wallet, "wallet_hash", "")


### PR DESCRIPTION
## Description
Added filter options to transaction outputs api and address info api for commerce-hub functions
- Added `wallet_hash` filter option to address info to only search addresses under the provided parameter.
- Fixed server error when address does not exists, returned empty response instead.
- Added `txid` and `index` param in transaction output api

## Screenshots (if applicable):
n/a


## Type of Change
- [x] New feature (non-breaking change which adds functionality)


## Test Notes
Tested added query parameters of updated endpoints through chipnet server