### PR TITLE
set expiration of 5 minutes to cached results for balance & history api

### DIFF
--- a/main/views/view_balance.py
+++ b/main/views/view_balance.py
@@ -272,7 +272,7 @@ class Balance(APIView):
                         data['yield'] = None # compute_wallet_yield(wallet_hash)
                         data['valid'] = True
 
-                        cache.set(bch_cache_key, json.dumps(data))
+                        cache.set(bch_cache_key, json.dumps(data), ex=60 * 5) # 5 minutes
                 else:
                     ct_cache_key = f'wallet:balance:token:{wallet_hash}:{_category}'
                     cached_data = cache.get(ct_cache_key)
@@ -305,7 +305,7 @@ class Balance(APIView):
                             data['commitment'] = token.commitment
                             data['capability'] = token.capability
 
-                        cache.set(ct_cache_key, json.dumps(data))
+                        cache.set(ct_cache_key, json.dumps(data), ex=60 * 5) # 5 minutes
 
             # Update last_balance_check timestamp
             wallet.last_balance_check = timezone.now()

--- a/main/views/view_history.py
+++ b/main/views/view_history.py
@@ -30,7 +30,7 @@ def store_object(key, obj, cache):
     # Convert binary to Base64 string
     encoded_data = base64.b64encode(pickled_data).decode('utf-8')
     # Store in Redis
-    cache.set(key, encoded_data)
+    cache.set(key, encoded_data, ex=60 * 5)  # Cache for 5 minutes
 
 
 def retrieve_object(key, cache):


### PR DESCRIPTION
## Description
Add expiration time of 5 minutes to cached results for balance & history api

Fixes # (issue)
n/a

## Screenshots (if applicable):
(Include screenshots for UI-related changes)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Tested manually with wallet balance and history api

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
