### PR TITLE
Fix/p2p exchange

### DIFF
--- a/rampp2p/consumers.py
+++ b/rampp2p/consumers.py
@@ -1,7 +1,6 @@
 from channels.generic.websocket import AsyncWebsocketConsumer
 from asgiref.sync import sync_to_async
 from rampp2p.utils import unread_orders_count
-from authentication.models import AuthToken
 from rampp2p.models import Peer
 from datetime import datetime
 import json
@@ -131,7 +130,7 @@ class GeneralUpdatesConsumer(AsyncWebsocketConsumer):
         try:
             user = Peer.objects.get(wallet_hash=wallet_hash)
             return user
-        except AuthToken.DoesNotExist:
+        except Exception:
             return None
     
     @sync_to_async
@@ -166,7 +165,6 @@ class CashinAlertsConsumer(AsyncWebsocketConsumer):
     async def disconnect(self, close_code):
         user = await self.get_user_from_wallet_hash(self.wallet_hash)
         await self.set_user_active(user, False)
-        await self.set_user_active(user, False)
         await self.channel_layer.group_discard(
             self.room_name,
             self.channel_name
@@ -181,7 +179,7 @@ class CashinAlertsConsumer(AsyncWebsocketConsumer):
         try:
             user = Peer.objects.get(wallet_hash=wallet_hash)
             return user
-        except AuthToken.DoesNotExist:
+        except Exception:
             return None
 
     @sync_to_async

--- a/rampp2p/validators.py
+++ b/rampp2p/validators.py
@@ -47,7 +47,8 @@ def validate_status_progression(new_status, order_id):
                 invalid_status = True
 
     if current_status.status == StatusType.ESCROW_PENDING:
-        if (new_status != StatusType.ESCROWED):
+        if (new_status != StatusType.ESCROWED and 
+            new_status != StatusType.CANCELED):
                 invalid_status = True
          
     if current_status.status == StatusType.ESCROWED:


### PR DESCRIPTION
## Description
This PR includes two changes:

- Fix error handling when fetching Peer in CashinAlertsConsumer
   - Previously, if a P2P exchange unregistered user triggered the cash-in alerts WebSocket, it would raise an error due to missing Peer data. The error is now handled to prevent WebSocket failure. 
- Allow canceling orders with `escrow_pending` status
   - Previously, users were blocked from canceling orders if the order was in escrow_pending state, making the "cancel order" button in the escrow page useless. This update extends cancel permission logic to include that status, allowing users to cancel such orders when appropriate.

## Screenshots (if applicable):
N/A


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
How Has This Been Tested?
- Manually tested the `CashinAlertsConsumer `WebSocket by using a P2P exchange unregistered user to simulate the error. Confirmed that the WebSocket previously failed but now runs without error.
- Manually tested cancel flow for orders in `escrow_pending` status and verified cancelation is now allowed.

No other core areas affected by these changes.

## @mentions
@joemarct 