### PR TITLE
set correct token id for cashtoken tx push notification

### DIFF
--- a/main/utils/push_notification.py
+++ b/main/utils/push_notification.py
@@ -30,6 +30,12 @@ def send_wallet_history_push_notification(wallet_history_obj):
         "token_id": wallet_history_obj.token.tokenid,
     }
 
+    if wallet_history_obj.token.tokenid == settings.WT_DEFAULT_CASHTOKEN_ID:
+        if wallet_history_obj.cashtoken_ft:
+            extra["token_id"] = wallet_history_obj.cashtoken_ft.token_id
+        elif wallet_history_obj.cashtoken_nft:
+            extra["token_id"] = wallet_history_obj.cashtoken_nft.token_id
+
     if incoming:
         # title = "Payment Received" if incoming else "Payment Sent"
         title = "Payment Received"
@@ -71,7 +77,7 @@ def send_wallet_history_push_notification_nft(wallet_history_obj):
         extra = {
             "txid": wallet_history_obj.txid,
             "type": NotificationTypes.MAIN_TRANSACTION,
-            "token_id": wallet_history_obj.token.tokenid,
+            "token_id": wallet_history_obj.cashtoken_nft.token_id,
         }
 
         broadcast_to_engagementhub({

--- a/main/utils/push_notification.py
+++ b/main/utils/push_notification.py
@@ -27,14 +27,8 @@ def send_wallet_history_push_notification(wallet_history_obj):
     extra = {
         "txid": wallet_history_obj.txid,
         "type": NotificationTypes.MAIN_TRANSACTION,
-        "token_id": wallet_history_obj.token.tokenid,
+        "token_id": resolve_token_id_for_notifications(wallet_history_obj),
     }
-
-    if wallet_history_obj.token.tokenid == settings.WT_DEFAULT_CASHTOKEN_ID:
-        if wallet_history_obj.cashtoken_ft:
-            extra["token_id"] = wallet_history_obj.cashtoken_ft.token_id
-        elif wallet_history_obj.cashtoken_nft:
-            extra["token_id"] = wallet_history_obj.cashtoken_nft.token_id
 
     if incoming:
         # title = "Payment Received" if incoming else "Payment Sent"
@@ -97,4 +91,14 @@ def send_wallet_history_push_notification_nft(wallet_history_obj):
         )
 
 def parse_transaction_extra_data(wallet_history):
-    return f'{wallet_history.txid};{wallet_history.token.pk}'
+    token_id = resolve_token_id_for_notifications(wallet_history)
+    return f'{wallet_history.txid};{token_id}'
+
+def resolve_token_id_for_notifications(wallet_history_obj):
+    if wallet_history_obj.token and wallet_history_obj.token.tokenid != settings.WT_DEFAULT_CASHTOKEN_ID:
+        return wallet_history_obj.token.tokenid
+
+    if wallet_history_obj.cashtoken_ft:
+        return wallet_history_obj.cashtoken_ft.token_id
+    elif wallet_history_obj.cashtoken_nft:
+        return wallet_history_obj.cashtoken_nft.token_id


### PR DESCRIPTION
## Description
Update token id sent from push notifications service and engagement hub mqtt for push notifs. Fixes bug in paytaca app being unable to find transactions when opening cashtoken transaction notifications due to incorrect token id in push notification payload.

## Screenshots (if applicable):
(Include screenshots for UI-related changes)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
- Send cashtokens from another wallet to own wallet. Opening push notification from app should display the transaction details (Existing notifications in notifications dialog might have incorrect push notif data and not work).

## @mentions
https://github.com/paytaca/paytaca-app/pull/509
