### PR TITLE
fix: Resolve ARS-BCH market price mismatch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,8 @@ services:
       - /code/cts/js/node_modules
       - /code/vouchers/js/node_modules
       - /code/stablehedge/js/node_modules
+      - /code/main/js/node_modules
+      - /code/multisig/js/node_modules
 volumes:
   watchtower_db_data:
     # external: true

--- a/rampp2p/tasks/task_marketprice.py
+++ b/rampp2p/tasks/task_marketprice.py
@@ -1,10 +1,7 @@
 from celery import shared_task
-import requests
-from decimal import Decimal
-
 from rampp2p.utils.websocket import send_market_price
+from main.utils.market_price import get_latest_bch_rates
 import rampp2p.models as models
-
 import logging
 logger = logging.getLogger(__name__)
 
@@ -12,84 +9,21 @@ logger = logging.getLogger(__name__)
 def update_market_prices():
     """
     Updates the market prices for subscribed fiat currencies.
-
-    This function fetches the latest market prices for Bitcoin Cash (BCH) from CoinGecko and Fullstack.cash.
-    It updates the MarketPrice model with the fetched prices and sends the updated prices through a websocket channel.
-
-    Returns:
-        None
     """
 
     try:
-        # get subscribed fiat currencies
         currencies = models.FiatCurrency.objects.all().values_list('symbol', flat=True)
+        bch_prices = get_latest_bch_rates(currencies)
 
-        # get market prices from coingecko
-        market_prices = get_latest_bch_prices_coingecko(currencies)
-        result_keys = []
-        
-        if market_prices:
-            result_keys = [e.upper() for e in list(market_prices.keys())]
+        for currency, data in bch_prices.items():
+            price_value, _, _ = data
+            
+            rate, _ = models.MarketPrice.objects.get_or_create(currency=currency.upper())
+            rate.price = price_value
+            rate.save()
 
-        # get missing market prices from fullstack.cash
-        if len(result_keys) < len(currencies):
-            mcurrencies = list(set(currencies) - set(result_keys))
-            market_prices_fullstackcash = get_latest_bch_prices_fullstackcash(mcurrencies)
-            if market_prices:
-                market_prices.update(market_prices_fullstackcash)
-            else:
-                market_prices = market_prices_fullstackcash
-
-        for currency in market_prices:
-            price = market_prices.get(currency)
-            if price:
-                rate, _ = models.MarketPrice.objects.get_or_create(currency=currency.upper())
-                rate.price = price
-                rate.save()
-            data =  { 'currency': currency, 'price' : price }
+            data =  { 'currency': currency, 'price' : price_value }
             send_market_price(data, currency)
             
     except Exception as e:
         logger.error(f"Error updating market prices: {e}")
-
-def get_latest_bch_prices_coingecko(currencies):
-    """
-    Fetches the latest BCH prices from CoinGecko.
-
-    This function sends a request to the CoinGecko API to retrieve the latest BCH prices
-    for the specified fiat currencies.
-
-    Args:
-        currencies (list): A list of fiat currency symbols.
-
-    Returns:
-        dict: A dictionary containing the latest BCH prices for the specified currencies.
-    """
-    coin_id = "bitcoin-cash"
-    query = { "ids": coin_id, "vs_currencies": ','.join(currencies) }
-    response = requests.get("https://api.coingecko.com/api/v3/simple/price/", params=query)
-    data = response.json()
-    return data.get(coin_id)
-
-def get_latest_bch_prices_fullstackcash(currencies):
-    """
-    Fetches the latest BCH prices from Fullstack.cash.
-
-    This function sends a request to the Fullstack.cash API to retrieve the latest BCH prices
-    for the specified fiat currencies.
-
-    Args:
-        currencies (list): A list of fiat currency symbols.
-
-    Returns:
-        dict: A dictionary containing the latest BCH prices for the specified currencies.
-    """
-    response = requests.get("https://api.fullstack.cash/v5/price/rates")
-    data = response.json()
-
-    rates = {}
-    for currency in currencies:
-        price = data.get(currency)
-        if price:
-            rates[currency] = Decimal(price)
-    return rates

--- a/supervisor/webserver.conf
+++ b/supervisor/webserver.conf
@@ -95,3 +95,39 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 stopasgroup=true
+
+[program:celery_wallet_history_1]
+command=celery -A watchtower worker -n worker6 -l INFO -Ofair -Q wallet_history_1 --max-tasks-per-child=100  --autoscale=1,5
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stopasgroup=true
+
+[program:celery_wallet_history_2]
+command=celery -A watchtower worker -n worker7 -l INFO -Ofair -Q wallet_history_2 --max-tasks-per-child=100  --autoscale=1,5
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stopasgroup=true
+
+[program:celery_save_record]
+command=celery -A watchtower worker -n worker4 -l INFO -Ofair -Q save_record --max-tasks-per-child=100  --autoscale=1,8
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stopasgroup=true
+
+[program:celery_post_save_record]
+command=celery -A watchtower worker -n worker5 -l INFO -Ofair -Q post_save_record --max-tasks-per-child=100  --autoscale=1,10
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stopasgroup=true


### PR DESCRIPTION
## Description

Fixes an issue where the BCH-ARS market price in the P2P exchange did not match the main page.
The P2P exchange now uses the main app’s market price fetch method, which correctly handles the ARS special case.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test Notes
- Verified that the ARS price in P2P Exchange now matches the market price in the main page.
- No breaking changes introduced.

## @mentions
@joemarct 
