### PR TITLE
Improvements/wallet subscription

### DIFF
--- a/main/serializers/serializer_subscriber.py
+++ b/main/serializers/serializer_subscriber.py
@@ -14,3 +14,4 @@ class SubscriberSerializer(serializers.Serializer):
     wallet_index = serializers.IntegerField(required=False, allow_null=True)
     address_index = serializers.IntegerField(required=False, allow_null=True)
     webhook_url = serializers.CharField(max_length=200, required=False, allow_blank=True)
+    remove_duplicate_path = serializers.BooleanField(default=False)

--- a/main/urls.py
+++ b/main/urls.py
@@ -75,6 +75,7 @@ main_urls += [
     re_path(r"^vouchers/device-vaults/$", views.VoucherTempView.as_view(), name='vouchers-temp'),
 
     re_path(r"^wallet-addresses/(?P<wallethash>[\w+:]+)/$", views.WalletAddressesView.as_view(),name='wallet-addresses'),
+    re_path(r"^wallet-address-paths/(?P<wallethash>[\w+:]+)/$", views.WalletAddressPathsView.as_view(),name='wallet-address-paths'),
 
     # re_path(r"^tokens/(?P<tokenid>[\w+:]+)/$", views.TokensView.as_view(),name='tokens'),
     path('transaction/spender/', views.SpenderTransactionView.as_view(), name='find-transaction-spender'),


### PR DESCRIPTION
## Description
Changes for wallet addresses resubscription
- Added api to fetch address paths of subscribed addresses of a wallet
- Added flag in subscription api to unsubscribe and unlink duplicate address paths


## Screenshots (if applicable):
n/a


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
- Tested using this [script](https://gist.github.com/khirvy019/586400137da5fe0a2c82ae2cfb575aa9)
  - To be safe, make a new wallet in paytaca-app and generate new addresses multiple times. Or run a local dev server.
  - You can put incorrect indices (e.g. `addressIndex + 1`) in [line 46](https://gist.github.com/khirvy019/586400137da5fe0a2c82ae2cfb575aa9#file-script-js-L46]) first to subscribe incorrect address/path pairing in.
  - Rerun again with correct address indices in line 56

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
