### PR TITLE
Fix/stablehedge tx metadata

### DIFF
--- a/stablehedge/admin.py
+++ b/stablehedge/admin.py
@@ -11,7 +11,7 @@ from stablehedge.functions.treasury_contract import (
     get_spendable_sats,
 )
 from stablehedge.functions.redemption_contract import get_24hr_volume_data, consolidate_redemption_contract
-from stablehedge.functions.transaction import update_redemption_contract_tx_trade_size
+from stablehedge.functions.transaction import update_redemption_contract_tx_trade_size, save_redemption_contract_tx_meta
 from stablehedge.js.runner import ScriptFunctions
 from stablehedge.utils.blockchain import broadcast_transaction
 from stablehedge.utils.wallet import subscribe_address
@@ -148,6 +148,7 @@ class RedemptionContractTransactionAdmin(admin.ModelAdmin):
 
     actions = [
         "recalculate_trade_size",
+        "update_tx_meta",
     ]
 
     def recalculate_trade_size(self, request, queryset):
@@ -161,6 +162,17 @@ class RedemptionContractTransactionAdmin(admin.ModelAdmin):
 
         messages.info(request, f"Updated count: {count}")
     recalculate_trade_size.short_description = "Recalculate trade size"
+
+    def update_tx_meta(self, request, queryset):
+        count = 0
+        for obj in queryset:
+            result = save_redemption_contract_tx_meta(obj)
+            if count < 10:
+                messages.info(request, f"{result}")
+            count += 1
+
+        messages.info(request, f"Updated count: {count}")
+    update_tx_meta.short_description = "Update transaction meta attributes data"
 
 class TreasuryContractKeyInline(admin.StackedInline):
     model = models.TreasuryContractKey

--- a/stablehedge/functions/transaction.py
+++ b/stablehedge/functions/transaction.py
@@ -343,6 +343,7 @@ def get_redemption_contract_tx_meta(redemption_contract_tx:models.RedemptionCont
     currency = redemption_contract_tx.redemption_contract.fiat_token.currency
     decimals = redemption_contract_tx.redemption_contract.fiat_token.decimals
 
+    trade_size_amount = round(redemption_contract_tx.trade_size_in_token_units / 10 ** decimals, decimals)
     data = {
         "id": redemption_contract_tx.id,
         "redemption_contract": redemption_contract_address,
@@ -350,7 +351,7 @@ def get_redemption_contract_tx_meta(redemption_contract_tx:models.RedemptionCont
         "price": round(price_value / 10 ** decimals, decimals),
         "currency": currency,
         "satoshis": str(redemption_contract_tx.trade_size_in_satoshis),
-        "amount": str(redemption_contract_tx.trade_size_in_token_units),
+        "amount": "{:.{}f}".format(trade_size_amount, decimals),
     }
 
     return dict(success=True, data=data, txid=txid)


### PR DESCRIPTION
## Description
Fixed incorrect token amount being saved in stablehedge's transaction metadata attribute


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test Notes
Tested by running `Update transaction meta attributes data` in `Stablehedge > Redemption contract transactions` 