### PR TITLE
Fix attribute queryset filter on wallet history endpoint

### DIFF
--- a/main/views/view_history.py
+++ b/main/views/view_history.py
@@ -157,7 +157,7 @@ class WalletHistoryView(APIView):
             qs = WalletHistory.objects.exclude(amount=0)
 
             if attribute:
-                meta_attributes = TransactionMetaAttribute.objects.filter(wallet_hash=wallet_hash)
+                meta_attributes = TransactionMetaAttribute.objects.filter(wallet_hash=wallet_hash, value=attribute)
                 wallet_txids_with_attrs = meta_attributes.values('txid').distinct('txid')
                 qs = qs.filter(txid__in=wallet_txids_with_attrs)
 


### PR DESCRIPTION
## Description
- Fixed a non-working filtering of the wallet history endpoint by transaction meta attribute

Fixes # (issue)
- Fixed a non-working filtering of the wallet history endpoint by transaction meta attribute

## Screenshots (if applicable):
- N/A


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
- Tested by checking the filter using local API docs


## @mentions
@joemarct 
