### PR TITLE
Fix/jpp protobuf

### DIFF
--- a/jpp/renderers.py
+++ b/jpp/renderers.py
@@ -21,6 +21,7 @@ class ProtobufRenderer(renderers.BaseRenderer):
         "application/octet-stream",
     ]
     format = "binary"
+    charset = None
 
     def render(self, data, *args, accepted_media_type=None, renderer_context=None, **kwargs):
         if isinstance(data, (dict, list, str)):

--- a/jpp/utils/verify.py
+++ b/jpp/utils/verify.py
@@ -1,3 +1,4 @@
+import math
 from bitcoinrpc.authproxy import JSONRPCException
 
 from main.utils.address_converter import address_to_locking_bytecode
@@ -75,6 +76,7 @@ def verify_tx_hex(invoice_obj, tx_hex, verify_inputs=True):
 
         tx_fee = tx_total_input - tx_total_output
         expected_tx_fee = invoice_obj.required_fee_per_byte * tx["size"]
+        expected_tx_fee = math.ceil(expected_tx_fee)
         if tx_fee < expected_tx_fee:
             raise VerifyError(f"Expected tx fee of {expected_tx_fee} satoshis but got {tx_fee} satoshis")
 


### PR DESCRIPTION
## Description
- Fix JPP invoice response header adding additional `charset=utf-8` in `Content-Type` header. Needed for compliance with Electron-Cash's implementation
- Fixed tx fee calculation during jpp payment tx verification

Fixes # (issue)


## Screenshots (if applicable):
(Include screenshots for UI-related changes)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Tested paying invoices with Bitcoin.com wallet and Electron-cash

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
