### PR TITLE
Improvement/msig proposal status update

### DIFF
--- a/multisig/apps.py
+++ b/multisig/apps.py
@@ -4,4 +4,5 @@ from django.apps import AppConfig
 class MultisigConfig(AppConfig):
     name = 'multisig'
 
-    
+    def ready(self):
+        import multisig.signals

--- a/multisig/signals.py
+++ b/multisig/signals.py
@@ -1,0 +1,16 @@
+import logging
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from main.models import (
+    TransactionBroadcast,
+)
+from multisig.tasks import update_proposal_status_on_broadcast
+
+LOGGER = logging.getLogger(__name__)
+
+@receiver(post_save, sender=TransactionBroadcast)
+def transaction_broadcast_post_save(sender, instance=None, created=False, **kwargs):
+    LOGGER.info(f"created {instance}")
+    if created and instance.tx_hex:
+        update_proposal_status_on_broadcast.delay(instance.id, instance.txid, instance.tx_hex)
+        

--- a/multisig/signals.py
+++ b/multisig/signals.py
@@ -1,4 +1,5 @@
 import logging
+from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from main.models import (
@@ -8,9 +9,12 @@ from multisig.tasks import update_proposal_status_on_broadcast
 
 LOGGER = logging.getLogger(__name__)
 
+
 @receiver(post_save, sender=TransactionBroadcast)
 def transaction_broadcast_post_save(sender, instance=None, created=False, **kwargs):
-    LOGGER.info(f"created {instance}")
     if created and instance.tx_hex:
-        update_proposal_status_on_broadcast.delay(instance.id, instance.txid, instance.tx_hex)
-        
+        transaction.on_commit(
+            lambda: update_proposal_status_on_broadcast.delay(
+                instance.id, instance.txid, instance.tx_hex
+            )
+        )

--- a/multisig/tasks.py
+++ b/multisig/tasks.py
@@ -1,38 +1,50 @@
-
 import logging
-from django.db import transaction, IntegrityError
+from django.db import transaction
 from celery import shared_task
 from multisig.js_client import get_unsigned_transaction_hash
 from multisig.models import Proposal
 
 LOGGER = logging.getLogger(__name__)
 
-@shared_task(rate_limit='20/s', queue='post_save_record')
+
+@shared_task(rate_limit="2/s", queue="post_save_record")
 def update_proposal_status_on_broadcast(transaction_broadcast_id, txid, tx_hex):
-    
-    LOGGER.info(f"broadcasted_tx_hex {tx_hex}")
-    unsigned_transaction_hash = None
-    response = get_unsigned_transaction_hash(tx_hex)
-    if response.status_code == 200:
+    try:
+        response = get_unsigned_transaction_hash(tx_hex)
+        if response.status_code != 200:
+            LOGGER.error(
+                f"get_unsigned_transaction_hash failed with status {response.status_code}"
+            )
+            return
         response_json = response.json()
-        LOGGER.info(f"response_json {response_json}")
-        unsigned_transaction_hash = response_json.get('unsigned_transaction_hash')
+        unsigned_transaction_hash = response_json.get("unsigned_transaction_hash")
+    except Exception as e:
+        LOGGER.exception(f"Error getting unsigned transaction hash: {e}")
+        return
 
-    if unsigned_transaction_hash:
-        LOGGER.info(f"unsigned_transaction_hash {unsigned_transaction_hash}")
-        proposal = Proposal.objects.filter(
-            unsigned_transaction_hash=unsigned_transaction_hash
-        ).first()
+    if not unsigned_transaction_hash:
+        LOGGER.warning(f"No unsigned_transaction_hash found for tx_hex")
+        return
 
+    proposal = Proposal.objects.filter(
+        unsigned_transaction_hash=unsigned_transaction_hash
+    ).first()
+
+    if proposal:
         with transaction.atomic():
-            if proposal:
-                proposal.txid = txid
-                proposal.status = Proposal.Status.BROADCAST_INITIATED
-                proposal.on_premise_transaction_broadcast_id = transaction_broadcast_id
-                proposal.save(update_fields=["txid", "status", "on_premise_transaction_broadcast"])
-            if proposal.inputs:
+            proposal.txid = txid
+            proposal.status = Proposal.Status.BROADCAST_INITIATED
+            proposal.on_premise_transaction_broadcast_id = transaction_broadcast_id
+            proposal.save(
+                update_fields=["txid", "status", "on_premise_transaction_broadcast"]
+            )
+
+            if proposal.inputs.exists():
                 for input in proposal.inputs.all():
                     input.spending_txid = txid
                     input.save()
-                    LOGGER.info(f"Proposal Found {proposal}")
-
+                LOGGER.info(f"Updated proposal {proposal.id} with txid {txid}")
+    else:
+        LOGGER.warning(
+            f"No proposal found for unsigned_transaction_hash {unsigned_transaction_hash}"
+        )

--- a/multisig/tasks.py
+++ b/multisig/tasks.py
@@ -1,0 +1,38 @@
+
+import logging
+from django.db import transaction, IntegrityError
+from celery import shared_task
+from multisig.js_client import get_unsigned_transaction_hash
+from multisig.models import Proposal
+
+LOGGER = logging.getLogger(__name__)
+
+@shared_task(rate_limit='20/s', queue='post_save_record')
+def update_proposal_status_on_broadcast(transaction_broadcast_id, txid, tx_hex):
+    
+    LOGGER.info(f"broadcasted_tx_hex {tx_hex}")
+    unsigned_transaction_hash = None
+    response = get_unsigned_transaction_hash(tx_hex)
+    if response.status_code == 200:
+        response_json = response.json()
+        LOGGER.info(f"response_json {response_json}")
+        unsigned_transaction_hash = response_json.get('unsigned_transaction_hash')
+
+    if unsigned_transaction_hash:
+        LOGGER.info(f"unsigned_transaction_hash {unsigned_transaction_hash}")
+        proposal = Proposal.objects.filter(
+            unsigned_transaction_hash=unsigned_transaction_hash
+        ).first()
+
+        with transaction.atomic():
+            if proposal:
+                proposal.txid = txid
+                proposal.status = Proposal.Status.BROADCAST_INITIATED
+                proposal.on_premise_transaction_broadcast_id = transaction_broadcast_id
+                proposal.save(update_fields=["txid", "status", "on_premise_transaction_broadcast"])
+            if proposal.inputs:
+                for input in proposal.inputs.all():
+                    input.spending_txid = txid
+                    input.save()
+                    LOGGER.info(f"Proposal Found {proposal}")
+

--- a/multisig/views/transaction.py
+++ b/multisig/views/transaction.py
@@ -381,13 +381,22 @@ class ProposalStatusView(APIView):
             if spending_txid:
                 inp.spending_txid = spending_txid
                 inp.save(update_fields=["spending_txid"])
-                spending_transaction = NODE.BCH._get_raw_transaction(spending_txid)
-
+                # Try on-premise broadcast first
+                transaction_broadcast = TransactionBroadcast.objects.filter(txid=spending_txid).first()
+                if transaction_broadcast and transaction_broadcast.tx_hex:
+                    spending_transaction = transaction_broadcast.tx_hex
+                else:
+                    try:
+                        raw_transaction = NODE.BCH._get_raw_transaction(spending_txid)
+                        spending_transaction = raw_transaction.get("hex")
+                    except Exception as e:
+                        LOGGER.error(f"Failed to get raw transaction from node {e}")
+                
             spending_transaction_unsigned_transaction_hash = None
             if spending_transaction:
                 get_unsigned_transaction_hash_resp = (
                     js_client.get_unsigned_transaction_hash(
-                        spending_transaction["hex"]
+                        spending_transaction
                     )
                 )
                 spending_transaction_unsigned_transaction_hash = (


### PR DESCRIPTION
## Description
Added signal handler to automatically update Proposal status when a TransactionBroadcast is created. This ensures proposal status and input spending txids are updated without manual intervention

Additionally, optimized the ProposalStatusView to check the TransactionBroadcast table first before querying the BCH node for raw transaction data, reducing unnecessary node calls.

Fixes # (issue)
Fixes delay in updating the proposal status from 'pending' to 'broadcast'

## Screenshots (if applicable):
(Include screenshots for UI-related changes)


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Tested on local watchtower instance
- Create a TransactionBroadcast with a valid tx_hex that matches a Proposal's unsigned_transaction_hash
- Verify the Proposal status updates to BROADCAST_INITIATED
- Verify the Proposal's inputs are updated with the correct spending_txid
- Test ProposalStatusView endpoint to confirm it retrieves transaction data from TransactionBroadcast table before falling back to BCH node
- Test error handling when BCH node is unavailable

