### PR TITLE
feat(rampp2p): add early upload-by-method endpoint and idempotent OrderPayment creation

### DIFF
--- a/rampp2p/migrations/0235_orderpayment_unique_together.py
+++ b/rampp2p/migrations/0235_orderpayment_unique_together.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("rampp2p", "0234_add_performance_indexes"),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="orderpayment",
+            unique_together={("order", "payment_method")},
+        ),
+    ]

--- a/rampp2p/models/model_order.py
+++ b/rampp2p/models/model_order.py
@@ -11,15 +11,30 @@ from .model_peer import Peer
 from .model_arbiter import Arbiter
 from .model_payment import PaymentMethod, PaymentType
 
+
 class Order(models.Model):
     tracking_id = models.CharField(max_length=50, null=True, blank=True, unique=True)
-    ad_snapshot = models.ForeignKey(AdSnapshot, on_delete=models.PROTECT, editable=False)
-    owner = models.ForeignKey(Peer, on_delete=models.PROTECT, editable=False, related_name="created_orders")
+    ad_snapshot = models.ForeignKey(
+        AdSnapshot, on_delete=models.PROTECT, editable=False
+    )
+    owner = models.ForeignKey(
+        Peer, on_delete=models.PROTECT, editable=False, related_name="created_orders"
+    )
     chat_session_ref = models.CharField(max_length=100, null=True, blank=True)
-    arbiter = models.ForeignKey(Arbiter, on_delete=models.PROTECT, blank=True, null=True, related_name="arbitrated_orders")
-    locked_price = models.DecimalField(max_digits=18, decimal_places=8, default=0, editable=False)
-    crypto_amount = models.DecimalField(max_digits=18, decimal_places=8, default=0, null=True, editable=False) # order trade amount in BCH (to be deprecated)
-    trade_amount = models.BigIntegerField(null=True) # order trade amount in satoshis
+    arbiter = models.ForeignKey(
+        Arbiter,
+        on_delete=models.PROTECT,
+        blank=True,
+        null=True,
+        related_name="arbitrated_orders",
+    )
+    locked_price = models.DecimalField(
+        max_digits=18, decimal_places=8, default=0, editable=False
+    )
+    crypto_amount = models.DecimalField(
+        max_digits=18, decimal_places=8, default=0, null=True, editable=False
+    )  # order trade amount in BCH (to be deprecated)
+    trade_amount = models.BigIntegerField(null=True)  # order trade amount in satoshis
     payment_methods = models.ManyToManyField(PaymentMethod)
     created_at = models.DateTimeField(auto_now_add=True, editable=False)
     appealable_at = models.DateTimeField(null=True)
@@ -29,57 +44,53 @@ class Order(models.Model):
     class Meta:
         indexes = [
             # Optimize Order model for trade count calculations
-            models.Index(fields=['ad_snapshot'], name='rampp2p_order_ad_snapshot_idx'),
+            models.Index(fields=["ad_snapshot"], name="rampp2p_order_ad_snapshot_idx"),
         ]
 
     def __str__(self):
-        return f'{self.id}'
-    
+        return f"{self.id}"
+
     @property
     def status(self):
-        Status = apps.get_model('rampp2p', 'Status')
+        Status = apps.get_model("rampp2p", "Status")
         last_status = Status.objects.filter(order__id=self.id).last()
         return last_status
-    
+
     @property
     def trade_type(self):
         if self.ad_snapshot.trade_type == TradeType.SELL:
             return TradeType.BUY
         return TradeType.SELL
-    
+
     @property
     def currency(self):
         return self.ad_snapshot.fiat_currency
-    
+
     def is_appealable(self):
         appealable = False
         if self.appealable_at:
             time_now = timezone.make_aware(datetime.now())
             appealable = time_now >= self.appealable_at
         return appealable, self.appealable_at
-    
+
     def get_members(self):
-        OrderMember = apps.get_model('rampp2p', 'OrderMember')
+        OrderMember = apps.get_model("rampp2p", "OrderMember")
         members = OrderMember.objects.filter(order__id=self.id)
         arbiter, seller, buyer = None, None, None
         for member in members:
             type = member.type
-            if (type == OrderMember.MemberType.ARBITER):
+            if type == OrderMember.MemberType.ARBITER:
                 arbiter = member
-            if (type == OrderMember.MemberType.SELLER):
+            if type == OrderMember.MemberType.SELLER:
                 seller = member
-            if (type == OrderMember.MemberType.BUYER):
+            if type == OrderMember.MemberType.BUYER:
                 buyer = member
 
-        return {
-            'arbiter': arbiter,
-            'seller': seller,
-            'buyer': buyer
-        }
-    
+        return {"arbiter": arbiter, "seller": seller, "buyer": buyer}
+
     def is_seller(self, wallet_hash):
         seller = self.owner
-        if self.ad_snapshot.trade_type == 'SELL':
+        if self.ad_snapshot.trade_type == "SELL":
             seller = self.ad_snapshot.ad.owner
         if wallet_hash == seller.wallet_hash:
             return True
@@ -87,20 +98,20 @@ class Order(models.Model):
 
     def is_buyer(self, wallet_hash):
         buyer = self.owner
-        if self.ad_snapshot.trade_type == 'BUY':
+        if self.ad_snapshot.trade_type == "BUY":
             buyer = self.ad_snapshot.ad.owner
         if wallet_hash == buyer.wallet_hash:
             return True
         return False
-    
+
     def is_arbiter(self, wallet_hash):
         return wallet_hash == self.arbiter.wallet_hash
-    
+
     def get_seller(self):
         if self.ad_snapshot.trade_type == TradeType.SELL:
             return self.ad_snapshot.ad.owner
         return self.owner
-    
+
     def get_buyer(self):
         if self.ad_snapshot.trade_type == TradeType.BUY:
             return self.ad_snapshot.ad.owner
@@ -109,8 +120,14 @@ class Order(models.Model):
 
 class OrderPayment(models.Model):
     order = models.ForeignKey(Order, on_delete=models.CASCADE)
-    payment_method = models.ForeignKey(PaymentMethod, on_delete=models.SET_NULL, null=True)
+    payment_method = models.ForeignKey(
+        PaymentMethod, on_delete=models.SET_NULL, null=True
+    )
     payment_type = models.ForeignKey(PaymentType, on_delete=models.PROTECT)
+
+    class Meta:
+        unique_together = [["order", "payment_method"]]
+
 
 class ImageUpload(models.Model):
     url = models.URLField(null=True, blank=True)
@@ -118,61 +135,87 @@ class ImageUpload(models.Model):
     file_hash = models.CharField(max_length=70, null=True, blank=True, unique=True)
     size = models.IntegerField(null=True, blank=True)
 
+
 class OrderPaymentAttachment(models.Model):
     payment = models.ForeignKey(OrderPayment, on_delete=models.CASCADE)
     image = models.ForeignKey(ImageUpload, on_delete=models.CASCADE)
     created_at = models.DateTimeField(auto_now_add=True)
-        
+
+
 class OrderMember(models.Model):
     class MemberType(models.TextChoices):
-        SELLER = 'SELLER'
-        BUYER = 'BUYER'
-        ARBITER = 'ARBITER'
+        SELLER = "SELLER"
+        BUYER = "BUYER"
+        ARBITER = "ARBITER"
 
     type = models.CharField(max_length=10, choices=MemberType.choices, null=True)
-    order = models.ForeignKey(Order, on_delete=models.CASCADE, related_name='members')
-    peer = models.ForeignKey(Peer, on_delete=models.CASCADE, related_name='order_members', null=True, blank=True)
-    arbiter = models.ForeignKey(Arbiter, on_delete=models.CASCADE, related_name='order_members', null=True, blank=True)
+    order = models.ForeignKey(Order, on_delete=models.CASCADE, related_name="members")
+    peer = models.ForeignKey(
+        Peer,
+        on_delete=models.CASCADE,
+        related_name="order_members",
+        null=True,
+        blank=True,
+    )
+    arbiter = models.ForeignKey(
+        Arbiter,
+        on_delete=models.CASCADE,
+        related_name="order_members",
+        null=True,
+        blank=True,
+    )
     read_at = models.DateTimeField(null=True, blank=True)
 
     def __str__(self) -> str:
-        return f'{self.id}'
-    
+        return f"{self.id}"
+
     @property
     def user(self):
         if self.arbiter:
             return self.arbiter
         return self.peer
-        
+
     @property
     def name(self):
         user = self.user
         if user:
             return user.name
-    
+
     @property
     def wallet_hash(self):
         return self.user.wallet_hash
 
     class Meta:
-         constraints = [
+        constraints = [
             models.UniqueConstraint(
-                fields=['type', 'peer', 'order'],
+                fields=["type", "peer", "order"],
                 condition=models.Q(peer__isnull=False),
-                name='unique_peer_order'
+                name="unique_peer_order",
             ),
             models.UniqueConstraint(
-                fields=['type', 'arbiter', 'order'],
+                fields=["type", "arbiter", "order"],
                 condition=models.Q(arbiter__isnull=False),
-                name='unique_arbiter_order'
+                name="unique_arbiter_order",
             ),
         ]
 
+
 class OrderFeedback(models.Model):
-    from_peer = models.ForeignKey(Peer, on_delete=models.PROTECT, related_name='created_feedbacks', editable=False)
-    to_peer = models.ForeignKey(Peer, on_delete=models.PROTECT, related_name='received_feedbacks', editable=False)
-    order = models.ForeignKey(Order, on_delete=models.PROTECT, related_name='feedbacks', editable=False)
-    rating = models.IntegerField(validators=[MinValueValidator(1), MaxValueValidator(5)])
+    from_peer = models.ForeignKey(
+        Peer, on_delete=models.PROTECT, related_name="created_feedbacks", editable=False
+    )
+    to_peer = models.ForeignKey(
+        Peer,
+        on_delete=models.PROTECT,
+        related_name="received_feedbacks",
+        editable=False,
+    )
+    order = models.ForeignKey(
+        Order, on_delete=models.PROTECT, related_name="feedbacks", editable=False
+    )
+    rating = models.IntegerField(
+        validators=[MinValueValidator(1), MaxValueValidator(5)]
+    )
     comment = models.CharField(max_length=4000, blank=True)
     created_at = models.DateTimeField(auto_now_add=True, editable=False)
     modified_at = models.DateTimeField(auto_now=True)
@@ -180,17 +223,31 @@ class OrderFeedback(models.Model):
     class Meta:
         indexes = [
             # Optimize OrderFeedback for rating calculations
-            models.Index(fields=['to_peer', 'rating'], name='rampp2p_feedback_rating_idx'),
+            models.Index(
+                fields=["to_peer", "rating"], name="rampp2p_feedback_rating_idx"
+            ),
         ]
 
     def __str__(self):
         return str(self.id)
 
+
 class ArbiterFeedback(models.Model):
-    from_peer = models.ForeignKey(Peer, on_delete=models.PROTECT, related_name='arbiter_feedbacks', editable=False)
-    to_arbiter = models.ForeignKey(Arbiter, on_delete=models.PROTECT, related_name='feedbacks', editable=False)
-    order = models.ForeignKey(Order, on_delete=models.PROTECT, related_name='arbiter_feedbacks', editable=False)
-    rating = models.IntegerField(validators=[MinValueValidator(1), MaxValueValidator(5)])
+    from_peer = models.ForeignKey(
+        Peer, on_delete=models.PROTECT, related_name="arbiter_feedbacks", editable=False
+    )
+    to_arbiter = models.ForeignKey(
+        Arbiter, on_delete=models.PROTECT, related_name="feedbacks", editable=False
+    )
+    order = models.ForeignKey(
+        Order,
+        on_delete=models.PROTECT,
+        related_name="arbiter_feedbacks",
+        editable=False,
+    )
+    rating = models.IntegerField(
+        validators=[MinValueValidator(1), MaxValueValidator(5)]
+    )
     comment = models.CharField(max_length=4000, blank=True)
     created_at = models.DateTimeField(auto_now_add=True, editable=False)
     modified_at = models.DateTimeField(auto_now=True)
@@ -198,72 +255,80 @@ class ArbiterFeedback(models.Model):
     def __str__(self):
         return str(self.id)
 
+
 # class kept for legacy purposes
 class StatusType(models.TextChoices):
-    SUBMITTED         = 'SBM', _('Submitted')
-    CONFIRMED         = 'CNF', _('Confirmed')
-    ESCROW_PENDING    =  'ESCRW_PN', _('Escrow Pending')
-    ESCROWED          = 'ESCRW', _('Escrowed')
-    PAID_PENDING      = 'PD_PN', _('Paid Pending')
-    PAID              = 'PD', _('Paid')
-    APPEALED          = 'APL', _('Appealed')
-    RELEASE_PENDING   = 'RLS_PN', _('Release Pending')
-    RELEASED          = 'RLS', _('Released')
-    REFUND_PENDING    = 'RFN_PN', _('Refund Pending')
-    REFUNDED          = 'RFN', _('Refunded')
-    CANCELED          = 'CNCL', _('Canceled')
+    SUBMITTED = "SBM", _("Submitted")
+    CONFIRMED = "CNF", _("Confirmed")
+    ESCROW_PENDING = "ESCRW_PN", _("Escrow Pending")
+    ESCROWED = "ESCRW", _("Escrowed")
+    PAID_PENDING = "PD_PN", _("Paid Pending")
+    PAID = "PD", _("Paid")
+    APPEALED = "APL", _("Appealed")
+    RELEASE_PENDING = "RLS_PN", _("Release Pending")
+    RELEASED = "RLS", _("Released")
+    REFUND_PENDING = "RFN_PN", _("Refund Pending")
+    REFUNDED = "RFN", _("Refunded")
+    CANCELED = "CNCL", _("Canceled")
+
 
 class Status(models.Model):
-	class StatusType(models.TextChoices):
-		SUBMITTED         = 'SBM', _('Submitted')
-		CONFIRMED         = 'CNF', _('Confirmed')
-		ESCROW_PENDING    =  'ESCRW_PN', _('Escrow Pending')
-		ESCROWED          = 'ESCRW', _('Escrowed')
-		PAID_PENDING      = 'PD_PN', _('Paid Pending')
-		PAID              = 'PD', _('Paid')
-		APPEALED          = 'APL', _('Appealed')
-		RELEASE_PENDING   = 'RLS_PN', _('Release Pending')
-		RELEASED          = 'RLS', _('Released')
-		REFUND_PENDING    = 'RFN_PN', _('Refund Pending')
-		REFUNDED          = 'RFN', _('Refunded')
-		CANCELED          = 'CNCL', _('Canceled')
+    class StatusType(models.TextChoices):
+        SUBMITTED = "SBM", _("Submitted")
+        CONFIRMED = "CNF", _("Confirmed")
+        ESCROW_PENDING = "ESCRW_PN", _("Escrow Pending")
+        ESCROWED = "ESCRW", _("Escrowed")
+        PAID_PENDING = "PD_PN", _("Paid Pending")
+        PAID = "PD", _("Paid")
+        APPEALED = "APL", _("Appealed")
+        RELEASE_PENDING = "RLS_PN", _("Release Pending")
+        RELEASED = "RLS", _("Released")
+        REFUND_PENDING = "RFN_PN", _("Refund Pending")
+        REFUNDED = "RFN", _("Refunded")
+        CANCELED = "CNCL", _("Canceled")
 
-	status = models.CharField(max_length=10, choices=StatusType.choices, blank=False, db_index=True)
-	order = models.ForeignKey(Order, on_delete=models.CASCADE)
-	created_at = models.DateTimeField(auto_now_add=True, editable=False, db_index=True)
-	created_by = models.CharField(max_length=75, db_index=True, null=True, blank=True)
-	seller_read_at = models.DateTimeField(null=True, blank=True)
-	buyer_read_at = models.DateTimeField(null=True, blank=True)
+    status = models.CharField(
+        max_length=10, choices=StatusType.choices, blank=False, db_index=True
+    )
+    order = models.ForeignKey(Order, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True, editable=False, db_index=True)
+    created_by = models.CharField(max_length=75, db_index=True, null=True, blank=True)
+    seller_read_at = models.DateTimeField(null=True, blank=True)
+    buyer_read_at = models.DateTimeField(null=True, blank=True)
 
-	def __str__(self):
-		return str(self.id)
-	
-	def get_creator(self):
-		creator = None
-		wallet_hash = self.created_by
+    def __str__(self):
+        return str(self.id)
 
-		if wallet_hash:
-			Arbiter = apps.get_model('rampp2p', 'Arbiter')
-			arbiter = Arbiter.objects.filter(wallet_hash=wallet_hash)
-			if arbiter.exists():
-				creator = arbiter.first()
-			else:
-				Peer = apps.get_model('rampp2p', 'Peer')
-				peer = Peer.objects.filter(wallet_hash=wallet_hash)
-				if peer.exists():
-					creator = peer.first()
-		
-		return creator
+    def get_creator(self):
+        creator = None
+        wallet_hash = self.created_by
+
+        if wallet_hash:
+            Arbiter = apps.get_model("rampp2p", "Arbiter")
+            arbiter = Arbiter.objects.filter(wallet_hash=wallet_hash)
+            if arbiter.exists():
+                creator = arbiter.first()
+            else:
+                Peer = apps.get_model("rampp2p", "Peer")
+                peer = Peer.objects.filter(wallet_hash=wallet_hash)
+                if peer.exists():
+                    creator = peer.first()
+
+        return creator
+
 
 class AppealType(models.TextChoices):
-    RELEASE = 'RLS', _('Release')
-    REFUND  = 'RFN', _('Refund')
+    RELEASE = "RLS", _("Release")
+    REFUND = "RFN", _("Refund")
+
 
 class Appeal(models.Model):
     type = models.CharField(max_length=10, choices=AppealType.choices, db_index=True)
     reasons = models.TextField(blank=True, null=True)
-    owner = models.ForeignKey(Peer, on_delete=models.PROTECT, related_name='created_appeals')
-    order = models.OneToOneField(Order, on_delete=models.CASCADE, related_name='appeal')
+    owner = models.ForeignKey(
+        Peer, on_delete=models.PROTECT, related_name="created_appeals"
+    )
+    order = models.OneToOneField(Order, on_delete=models.CASCADE, related_name="appeal")
     resolved_at = models.DateTimeField(blank=True, null=True)
     created_at = models.DateTimeField(auto_now=True)
 
@@ -272,9 +337,10 @@ class Appeal(models.Model):
 
     def set_reasons(self, reasons):
         self.reasons = json.dumps(reasons)
-    
+
     def get_reasons(self):
         return json.loads(self.reasons) if self.reasons else []
+
 
 class Contract(models.Model):
     order = models.OneToOneField(Order, on_delete=models.CASCADE, unique=True)
@@ -286,8 +352,8 @@ class Contract(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, editable=False)
 
     def __str__(self):
-        return f'{self.id}'
-    
+        return f"{self.id}"
+
     def get_total_fees(self):
         total = None
         try:
@@ -295,39 +361,38 @@ class Contract(models.Model):
         except Exception as err:
             logger.exception(err.args[0])
         return total
-    
+
     def get_fees(self):
         return {
-            'service_fee': self.service_fee,
-            'arbitration_fee': self.arbitration_fee,
-            'contract_fee': self.contract_fee
+            "service_fee": self.service_fee,
+            "arbitration_fee": self.arbitration_fee,
+            "contract_fee": self.contract_fee,
         }
-    
+
     def get_members(self):
         members = ContractMember.objects.filter(contract__id=self.id)
         arbiter, seller, buyer = None, None, None
         for member in members:
             type = member.member_type
-            if (type == ContractMember.MemberType.ARBITER):
+            if type == ContractMember.MemberType.ARBITER:
                 arbiter = member
-            if (type == ContractMember.MemberType.SELLER):
+            if type == ContractMember.MemberType.SELLER:
                 seller = member
-            if (type == ContractMember.MemberType.BUYER):
+            if type == ContractMember.MemberType.BUYER:
                 buyer = member
-        
-        return {
-            'arbiter': arbiter, 
-            'seller': seller, 
-            'buyer': buyer
-        }
+
+        return {"arbiter": arbiter, "seller": seller, "buyer": buyer}
+
 
 class ContractMember(models.Model):
     class MemberType(models.TextChoices):
-        SELLER = 'SELLER'
-        BUYER = 'BUYER'
-        ARBITER = 'ARBITER'
+        SELLER = "SELLER"
+        BUYER = "BUYER"
+        ARBITER = "ARBITER"
 
-    contract = models.ForeignKey(Contract, on_delete=models.CASCADE, related_name='members')
+    contract = models.ForeignKey(
+        Contract, on_delete=models.CASCADE, related_name="members"
+    )
     member_ref_id = models.IntegerField()
     member_type = models.CharField(max_length=10, choices=MemberType.choices)
     pubkey = models.CharField(max_length=75)
@@ -336,16 +401,17 @@ class ContractMember(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, editable=False)
 
     class Meta:
-        unique_together = ('contract', 'member_type')
+        unique_together = ("contract", "member_type")
 
     def __str__(self):
-        return f'{self.address}'
+        return f"{self.address}"
+
 
 class Transaction(models.Model):
     class ActionType(models.TextChoices):
-        ESCROW = 'ESCROW'
-        REFUND = 'REFUND'
-        RELEASE = 'RELEASE'
+        ESCROW = "ESCROW"
+        REFUND = "REFUND"
+        RELEASE = "RELEASE"
 
     contract = models.ForeignKey(Contract, on_delete=models.CASCADE, editable=False)
     action = models.CharField(max_length=50, choices=ActionType.choices, db_index=True)
@@ -354,13 +420,18 @@ class Transaction(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, editable=False)
 
     def __str__(self):
-        return f'{self.id}'
+        return f"{self.id}"
+
 
 class Recipient(models.Model):
-    transaction = models.ForeignKey(Transaction, on_delete=models.CASCADE, related_name="recipients", editable=False)
+    transaction = models.ForeignKey(
+        Transaction, on_delete=models.CASCADE, related_name="recipients", editable=False
+    )
     address = models.CharField(max_length=200)
-    value = models.DecimalField(max_digits=18, decimal_places=8, default=0, editable=False)
+    value = models.DecimalField(
+        max_digits=18, decimal_places=8, default=0, editable=False
+    )
     created_at = models.DateTimeField(auto_now_add=True, editable=False)
 
     def __str__(self):
-        return f'{self.id}'
+        return f"{self.id}"

--- a/rampp2p/urls.py
+++ b/rampp2p/urls.py
@@ -3,94 +3,264 @@ from rampp2p.views import *
 from rest_framework.routers import DefaultRouter
 
 router = DefaultRouter()
-router.register(r'order/public', PublicOrdersViewSet, basename='public-orders')
-router.register(r'appeal/public', PublicAppealsViewSet, basename='public-appeals')
+router.register(r"order/public", PublicOrdersViewSet, basename="public-orders")
+router.register(r"appeal/public", PublicAppealsViewSet, basename="public-appeals")
 
 
 urlpatterns = [
     *router.urls,
-    path('version/check/<str:platform>/', check_app_version),
-    
-    path('ad/', AdViewSet.as_view({'get': 'list', 'post': 'create'})),
-    path('ad/<int:pk>/', AdViewSet.as_view({'get': 'retrieve', 'put': 'partial_update', 'delete': 'destroy'})),
-    path('ad/check/limit/', AdViewSet.as_view({'get': 'check_ad_limit'})),
-    path('ad/currency/', AdViewSet.as_view({'get': 'retrieve_currencies'})),
-    path('ad/snapshot/<int:pk>/', AdSnapshotViewSet.as_view({'get': 'retrieve'})),
-    path('ad/cash-in/', CashInAdViewSet.as_view({'get': 'list'})),
-    re_path(r'^ad/share/$', AdShareLinkView.as_view(), name='adview'),
-
-    path('cash-in/presets/', CashInAdViewSet.as_view({'get': 'list_presets'})),
-    path('cash-in/ad/payment-types/', CashInAdViewSet.as_view({'get': 'retrieve_ad_count_by_payment_types'})),
-    path('cash-in/ad/', CashInAdViewSet.as_view({'get': 'retrieve_ads_by_presets'})),
-    path('cash-in/order/', CashinOrderViewSet.as_view({'get': 'list'}), name='cashin-order-list'),
-    path('cash-in/order/alerts/', CashinOrderViewSet.as_view({'get': 'check_alerts'}), name='cashin-order-alerts'),
-
-    path('user/', UserAuthView.as_view(), name='user-profile'),
-    path('peer/', PeerViewSet.as_view({ 'get': 'retrieve_by_user', 'post': 'create', 'patch': 'partial_update' })),
-    path('peer/<int:pk>/', PeerViewSet.as_view({ 'get': 'retrieve'})),
-    path('peer/<str:wallet_hash>/', PeerViewSet.as_view({ 'get': 'retrieve_by_wallet'})),
-    path('arbiter/', ArbiterView.as_view(), name='arbiter-list-create-edit'),
-    path('arbiter/<str:wallet_hash>/', ArbiterView.as_view(), name='arbiter-detail'),
-
-    path('currency/fiat/', FiatCurrencyViewSet.as_view({'get': 'list'}), name='fiat-list'),
-    path('currency/fiat/<int:pk>/', FiatCurrencyViewSet.as_view({'get': 'retrieve'}), name='fiat-detail'),
-    path('currency/crypto/', CryptoCurrencyViewSet.as_view({'get': 'list'}), name='crypto-list'),
-    path('currency/crypto/<int:pk>/', CryptoCurrencyViewSet.as_view({'get': 'retrieve'}), name='crypto-detail'),
-
+    path("version/check/<str:platform>/", check_app_version),
+    path("ad/", AdViewSet.as_view({"get": "list", "post": "create"})),
+    path(
+        "ad/<int:pk>/",
+        AdViewSet.as_view(
+            {"get": "retrieve", "put": "partial_update", "delete": "destroy"}
+        ),
+    ),
+    path("ad/check/limit/", AdViewSet.as_view({"get": "check_ad_limit"})),
+    path("ad/currency/", AdViewSet.as_view({"get": "retrieve_currencies"})),
+    path("ad/snapshot/<int:pk>/", AdSnapshotViewSet.as_view({"get": "retrieve"})),
+    path("ad/cash-in/", CashInAdViewSet.as_view({"get": "list"})),
+    re_path(r"^ad/share/$", AdShareLinkView.as_view(), name="adview"),
+    path("cash-in/presets/", CashInAdViewSet.as_view({"get": "list_presets"})),
+    path(
+        "cash-in/ad/payment-types/",
+        CashInAdViewSet.as_view({"get": "retrieve_ad_count_by_payment_types"}),
+    ),
+    path("cash-in/ad/", CashInAdViewSet.as_view({"get": "retrieve_ads_by_presets"})),
+    path(
+        "cash-in/order/",
+        CashinOrderViewSet.as_view({"get": "list"}),
+        name="cashin-order-list",
+    ),
+    path(
+        "cash-in/order/alerts/",
+        CashinOrderViewSet.as_view({"get": "check_alerts"}),
+        name="cashin-order-alerts",
+    ),
+    path("user/", UserAuthView.as_view(), name="user-profile"),
+    path(
+        "peer/",
+        PeerViewSet.as_view(
+            {"get": "retrieve_by_user", "post": "create", "patch": "partial_update"}
+        ),
+    ),
+    path("peer/<int:pk>/", PeerViewSet.as_view({"get": "retrieve"})),
+    path("peer/<str:wallet_hash>/", PeerViewSet.as_view({"get": "retrieve_by_wallet"})),
+    path("arbiter/", ArbiterView.as_view(), name="arbiter-list-create-edit"),
+    path("arbiter/<str:wallet_hash>/", ArbiterView.as_view(), name="arbiter-detail"),
+    path(
+        "currency/fiat/", FiatCurrencyViewSet.as_view({"get": "list"}), name="fiat-list"
+    ),
+    path(
+        "currency/fiat/<int:pk>/",
+        FiatCurrencyViewSet.as_view({"get": "retrieve"}),
+        name="fiat-detail",
+    ),
+    path(
+        "currency/crypto/",
+        CryptoCurrencyViewSet.as_view({"get": "list"}),
+        name="crypto-list",
+    ),
+    path(
+        "currency/crypto/<int:pk>/",
+        CryptoCurrencyViewSet.as_view({"get": "retrieve"}),
+        name="crypto-detail",
+    ),
     # Orders
     # path('order/public/', PublicOrdersViewSet.as_view({'get': 'list'}), name='public-order-list-retrieve'),
     # path('order/public/<int:pk>/', PublicOrdersViewSet.as_view({'get': 'retrieve'}), name='public-order-detail'),
-    path('order/', OrderViewSet.as_view({'get': 'list', 'post': 'create'}), name='order-list-create'),
-    path('order/<int:pk>/', OrderViewSet.as_view({'get': 'retrieve', 'patch': 'partial_update'}), name='order-detail-edit'),
-    path('order/<int:pk>/ad/snapshot/', AdSnapshotViewSet.as_view({'get': 'retrieve_by_order'})),
-    path('order/<int:pk>/members/', OrderViewSet.as_view({'get': 'members', 'patch': 'members'}), name='order-members'),
-    path('order/<int:pk>/status/', OrderStatusViewSet.as_view({'get': 'list_status', 'patch': 'read_status'}), name='order-list-edit-status'),
-    path('order/<int:pk>/cancel/', OrderStatusViewSet.as_view({'post': 'cancel'}), name='order-cancel'),
-    path('order/<int:pk>/confirm/', OrderStatusViewSet.as_view({'post': 'confirm'}), name='order-confirm'),
-    path('order/<int:pk>/pending-escrow/', OrderStatusViewSet.as_view({'post': 'pending_escrow'}), name='order-pending-escrow'),
-    path('order/<int:pk>/confirm-payment/buyer/', OrderStatusViewSet.as_view({'post': 'buyer_confirm_payment'}), name='buyer-confirm-payment'),
-    path('order/<int:pk>/confirm-payment/seller/', OrderStatusViewSet.as_view({'post': 'seller_confirm_payment'}), name='seller-confirm-payment'),
-
+    path(
+        "order/",
+        OrderViewSet.as_view({"get": "list", "post": "create"}),
+        name="order-list-create",
+    ),
+    path(
+        "order/<int:pk>/",
+        OrderViewSet.as_view({"get": "retrieve", "patch": "partial_update"}),
+        name="order-detail-edit",
+    ),
+    path(
+        "order/<int:pk>/ad/snapshot/",
+        AdSnapshotViewSet.as_view({"get": "retrieve_by_order"}),
+    ),
+    path(
+        "order/<int:pk>/members/",
+        OrderViewSet.as_view({"get": "members", "patch": "members"}),
+        name="order-members",
+    ),
+    path(
+        "order/<int:pk>/status/",
+        OrderStatusViewSet.as_view({"get": "list_status", "patch": "read_status"}),
+        name="order-list-edit-status",
+    ),
+    path(
+        "order/<int:pk>/cancel/",
+        OrderStatusViewSet.as_view({"post": "cancel"}),
+        name="order-cancel",
+    ),
+    path(
+        "order/<int:pk>/confirm/",
+        OrderStatusViewSet.as_view({"post": "confirm"}),
+        name="order-confirm",
+    ),
+    path(
+        "order/<int:pk>/pending-escrow/",
+        OrderStatusViewSet.as_view({"post": "pending_escrow"}),
+        name="order-pending-escrow",
+    ),
+    path(
+        "order/<int:pk>/confirm-payment/buyer/",
+        OrderStatusViewSet.as_view({"post": "buyer_confirm_payment"}),
+        name="buyer-confirm-payment",
+    ),
+    path(
+        "order/<int:pk>/confirm-payment/seller/",
+        OrderStatusViewSet.as_view({"post": "seller_confirm_payment"}),
+        name="seller-confirm-payment",
+    ),
     # Contract
-    path('order/<int:pk>/contract/', ContractViewSet.as_view({'get': 'retrieve_by_order'}), name='order-contract-detail'),
-    path('order/<int:pk>/contract/fees/', ContractViewSet.as_view({'get': 'contract_fees'}), name='order-contract-fees'),
-    path('order/<int:pk>/contract/transactions/', ContractViewSet.as_view({'get': 'transactions_by_order'}), name='order-contract-tx'),
-    path('order/<int:pk>/verify-escrow/', ContractViewSet.as_view({'post': 'verify_escrow'}), name='verify-escrow'),
-    path('order/<int:pk>/verify-release/', ContractViewSet.as_view({'post': 'verify_release'}), name='verify-release'),
-    path('order/<int:pk>/verify-refund/', ContractViewSet.as_view({'post': 'verify_refund'}), name='verify-refund'),
-    path('order/contract/', ContractViewSet.as_view({'post': 'create'}), name='contract-create'),
-    path('order/contract/<int:pk>/', ContractViewSet.as_view({'get': 'retrieve'}), name='contract-detail'),
-    path('order/contract/<int:pk>/transactions/', ContractViewSet.as_view({'get': 'transactions'}), name='contract-tx'),
-    path('contract/fees/', ContractViewSet.as_view({'get': 'fees'}), name='contract-fees'),
-    
-    path('order/cash-in/', CashinOrderViewSet.as_view({'get': 'list'}), name='cashin-order-list'),
-    path('order/cash-in/alerts/', CashinOrderViewSet.as_view({'get': 'check_alerts'}), name='cashin-order-alerts'),
-    path('order/status/', OrderStatusViewSet.as_view({'patch': 'read_order_status'})),
-    
+    path(
+        "order/<int:pk>/contract/",
+        ContractViewSet.as_view({"get": "retrieve_by_order"}),
+        name="order-contract-detail",
+    ),
+    path(
+        "order/<int:pk>/contract/fees/",
+        ContractViewSet.as_view({"get": "contract_fees"}),
+        name="order-contract-fees",
+    ),
+    path(
+        "order/<int:pk>/contract/transactions/",
+        ContractViewSet.as_view({"get": "transactions_by_order"}),
+        name="order-contract-tx",
+    ),
+    path(
+        "order/<int:pk>/verify-escrow/",
+        ContractViewSet.as_view({"post": "verify_escrow"}),
+        name="verify-escrow",
+    ),
+    path(
+        "order/<int:pk>/verify-release/",
+        ContractViewSet.as_view({"post": "verify_release"}),
+        name="verify-release",
+    ),
+    path(
+        "order/<int:pk>/verify-refund/",
+        ContractViewSet.as_view({"post": "verify_refund"}),
+        name="verify-refund",
+    ),
+    path(
+        "order/contract/",
+        ContractViewSet.as_view({"post": "create"}),
+        name="contract-create",
+    ),
+    path(
+        "order/contract/<int:pk>/",
+        ContractViewSet.as_view({"get": "retrieve"}),
+        name="contract-detail",
+    ),
+    path(
+        "order/contract/<int:pk>/transactions/",
+        ContractViewSet.as_view({"get": "transactions"}),
+        name="contract-tx",
+    ),
+    path(
+        "contract/fees/", ContractViewSet.as_view({"get": "fees"}), name="contract-fees"
+    ),
+    path(
+        "order/cash-in/",
+        CashinOrderViewSet.as_view({"get": "list"}),
+        name="cashin-order-list",
+    ),
+    path(
+        "order/cash-in/alerts/",
+        CashinOrderViewSet.as_view({"get": "check_alerts"}),
+        name="cashin-order-alerts",
+    ),
+    path("order/status/", OrderStatusViewSet.as_view({"patch": "read_order_status"})),
     # Payment
-    path('order/payment/', OrderPaymentViewSet.as_view({'get': 'list'}), name='order-payment-list'),
-    path('order/payment/<int:pk>/', OrderPaymentViewSet.as_view({'get': 'retrieve'}), name='order-payment-detail'),
-    path('order/payment/<int:pk>/attachment/', OrderPaymentViewSet.as_view({'post': 'upload_attachment', 'delete': 'delete_attachment'}), name='payment-attachment-upload-delete'),
-    path('payment-type/', PaymentTypeView.as_view(), name='payment-type-list'),
-    path('payment-method/', PaymentMethodViewSet.as_view({'get': 'list', 'post': 'create'}), name='payment-method-list'),
-    path('payment-method/<int:pk>/', PaymentMethodViewSet.as_view({'get': 'retrieve', 'patch': 'partial_update', 'delete': 'destroy'}), name='payment-method-detail'),
-
+    path(
+        "order/payment/",
+        OrderPaymentViewSet.as_view({"get": "list"}),
+        name="order-payment-list",
+    ),
+    path(
+        "order/payment/<int:pk>/",
+        OrderPaymentViewSet.as_view({"get": "retrieve"}),
+        name="order-payment-detail",
+    ),
+    path(
+        "order/payment/<int:pk>/attachment/",
+        OrderPaymentViewSet.as_view(
+            {"post": "upload_attachment", "delete": "delete_attachment"}
+        ),
+        name="payment-attachment-upload-delete",
+    ),
+    path(
+        "order/payment/upload-by-method/",
+        OrderPaymentViewSet.as_view({"post": "upload_attachment_by_method"}),
+        name="payment-attachment-upload-by-method",
+    ),
+    path("payment-type/", PaymentTypeView.as_view(), name="payment-type-list"),
+    path(
+        "payment-method/",
+        PaymentMethodViewSet.as_view({"get": "list", "post": "create"}),
+        name="payment-method-list",
+    ),
+    path(
+        "payment-method/<int:pk>/",
+        PaymentMethodViewSet.as_view(
+            {"get": "retrieve", "patch": "partial_update", "delete": "destroy"}
+        ),
+        name="payment-method-detail",
+    ),
     # Appeal
-    path('appeal/', AppealViewSet.as_view({'get': 'list', 'post': 'create'}), name='appeal-list-create'),
-    path('appeal/<int:pk>/', AppealViewSet.as_view({'get': 'retrieve'}), name='appeal-detail'),
-    path('appeal/<int:pk>/pending-release/', AppealViewSet.as_view({'post': 'pending_release'}), name='appeal-pending-release'),
-    path('appeal/<int:pk>/pending-refund/', AppealViewSet.as_view({'post': 'pending_refund'}), name='appeal-pending-refund'),
-    path('order/<int:pk>/appeal/', AppealViewSet.as_view({'get': 'retrieve_by_order'}), name='order-appeal-detail'),
-
+    path(
+        "appeal/",
+        AppealViewSet.as_view({"get": "list", "post": "create"}),
+        name="appeal-list-create",
+    ),
+    path(
+        "appeal/<int:pk>/",
+        AppealViewSet.as_view({"get": "retrieve"}),
+        name="appeal-detail",
+    ),
+    path(
+        "appeal/<int:pk>/pending-release/",
+        AppealViewSet.as_view({"post": "pending_release"}),
+        name="appeal-pending-release",
+    ),
+    path(
+        "appeal/<int:pk>/pending-refund/",
+        AppealViewSet.as_view({"post": "pending_refund"}),
+        name="appeal-pending-refund",
+    ),
+    path(
+        "order/<int:pk>/appeal/",
+        AppealViewSet.as_view({"get": "retrieve_by_order"}),
+        name="order-appeal-detail",
+    ),
     # Feedback
-    path('order/feedback/arbiter/', ArbiterFeedbackViewSet.as_view({'get': 'list', 'post': 'create'}), name='arbiter-feedback-list-create'),
-    path('order/feedback/peer/', PeerFeedbackViewSet.as_view({'get': 'list', 'post': 'create'}), name='peer-feedback-list-create'),
-
+    path(
+        "order/feedback/arbiter/",
+        ArbiterFeedbackViewSet.as_view({"get": "list", "post": "create"}),
+        name="arbiter-feedback-list-create",
+    ),
+    path(
+        "order/feedback/peer/",
+        PeerFeedbackViewSet.as_view({"get": "list", "post": "create"}),
+        name="peer-feedback-list-create",
+    ),
     # Utils
-    path('utils/calculate-fees/', ContractFeeCalculation.as_view()),
-    path('utils/market-price/', MarketPrices.as_view(), name='market-price'),
-    path('utils/subscribe-address/', SubscribeContractAddress.as_view(), name='subscribe-address'),
-    path('chats/webhook/', ChatWebhookView.as_view(), name='chat-webhook'),
-    path('feature-toggles/', check_feature_control),
-    path('feature-control/', check_feature_control)
+    path("utils/calculate-fees/", ContractFeeCalculation.as_view()),
+    path("utils/market-price/", MarketPrices.as_view(), name="market-price"),
+    path(
+        "utils/subscribe-address/",
+        SubscribeContractAddress.as_view(),
+        name="subscribe-address",
+    ),
+    path("chats/webhook/", ChatWebhookView.as_view(), name="chat-webhook"),
+    path("feature-toggles/", check_feature_control),
+    path("feature-control/", check_feature_control),
 ]

--- a/rampp2p/views/view_order.py
+++ b/rampp2p/views/view_order.py
@@ -752,14 +752,11 @@ class OrderViewSet(viewsets.GenericViewSet):
     def create_order_payment_methods(self, payment_method_ids=[], order=None):
         payment_methods = models.PaymentMethod.objects.filter(id__in=payment_method_ids)
         for payment_method in payment_methods:
-            data = {
-                "order": order.id,
-                "payment_method": payment_method.id,
-                "payment_type": payment_method.payment_type.id,
-            }
-            order_method = serializers.OrderPaymentSerializer(data=data)
-            if order_method.is_valid():
-                order_method.save()
+            models.OrderPayment.objects.get_or_create(
+                order=order,
+                payment_method=payment_method,
+                defaults={"payment_type": payment_method.payment_type},
+            )
 
     def require_singular_cashin_order(self, wallet_hash=None):
         cancellable_cashin_orders = self.cancellable_cash_in_orders(wallet_hash)

--- a/rampp2p/views/view_order.py
+++ b/rampp2p/views/view_order.py
@@ -7,7 +7,16 @@ from django.http import Http404
 from django.utils import timezone
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
-from django.db.models import Q, OuterRef, Subquery, Case, When, Value, BooleanField, CharField
+from django.db.models import (
+    Q,
+    OuterRef,
+    Subquery,
+    Case,
+    When,
+    Value,
+    BooleanField,
+    CharField,
+)
 
 from decimal import Decimal
 from datetime import datetime, time, timedelta
@@ -30,65 +39,71 @@ from rampp2p.validators import *
 from rampp2p.pagination import StandardResultsSetPagination
 
 import logging
+
 logger = logging.getLogger(__name__)
+
 
 class CashinOrderViewSet(viewsets.GenericViewSet):
     queryset = models.Order.objects.all()
 
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def list(self, request):
-        wallet_hash = request.query_params.get('wallet_hash')
-        status_type = request.query_params.get('status_type')
-        owned = request.query_params.get('owned')
+        wallet_hash = request.query_params.get("wallet_hash")
+        status_type = request.query_params.get("status_type")
+        owned = request.query_params.get("owned")
         if owned is not None:
-            owned = owned == 'true'
+            owned = owned == "true"
 
         try:
-            limit = int(request.query_params.get('limit', 10))
-            page = int(request.query_params.get('page', 1))
+            limit = int(request.query_params.get("limit", 10))
+            page = int(request.query_params.get("page", 1))
             if limit < 0:
-                raise ValidationError('limit must be a non-negative number')
+                raise ValidationError("limit must be a non-negative number")
             if page < 1:
-                raise ValidationError('invalid page number')
+                raise ValidationError("invalid page number")
         except (ValueError, ValidationError) as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
         queryset = models.Order.objects.filter(is_cash_in=True)
-        
+
         # exclude completed orders
         completed_status = [
             StatusType.CANCELED,
             StatusType.RELEASED,
-            StatusType.REFUNDED
+            StatusType.REFUNDED,
         ]
-        last_status_subq = Status.objects.filter(
-            order=OuterRef('pk')
-        ).order_by('-created_at').values('status')[:1]
+        last_status_subq = (
+            Status.objects.filter(order=OuterRef("pk"))
+            .order_by("-created_at")
+            .values("status")[:1]
+        )
         queryset = queryset.annotate(last_status=Subquery(last_status_subq))
 
-        if status_type == 'ONGOING':
+        if status_type == "ONGOING":
             queryset = queryset.exclude(last_status__in=completed_status)
-        if status_type == 'COMPLETED':
+        if status_type == "COMPLETED":
             queryset = queryset.exclude(last_status__in=completed_status)
-        
+
         # fetches orders created by user
         owned_orders = Q(owner__wallet_hash=wallet_hash)
 
         if not owned:
             # fetches the orders that have ad ids owned by user
-            ad_orders = Q(ad_snapshot__ad__pk__in=list(
-                            # fetches the flat ids of ads owned by user
-                            models.Ad.objects.filter(
-                                owner__wallet_hash=wallet_hash
-                            ).values_list('id', flat=True)
-                        ))
+            ad_orders = Q(
+                ad_snapshot__ad__pk__in=list(
+                    # fetches the flat ids of ads owned by user
+                    models.Ad.objects.filter(
+                        owner__wallet_hash=wallet_hash
+                    ).values_list("id", flat=True)
+                )
+            )
 
             queryset = queryset.filter(owned_orders | ad_orders)
         else:
             queryset = queryset.filter(owned_orders)
 
-        queryset = queryset.order_by('-created_at')
-        
+        queryset = queryset.order_by("-created_at")
+
         # Count total pages
         count = queryset.count()
         total_pages = page
@@ -97,32 +112,29 @@ class CashinOrderViewSet(viewsets.GenericViewSet):
 
         # Splice queryset
         offset = (page - 1) * limit
-        page_results = queryset[offset:offset + limit]
+        page_results = queryset[offset : offset + limit]
 
-        context = { 'wallet_hash': wallet_hash }
-        serializer = serializers.OrderSerializer(page_results, many=True, context=context)
-        data = {
-            'orders': serializer.data,
-            'count': count,
-            'total_pages': total_pages
-        }
+        context = {"wallet_hash": wallet_hash}
+        serializer = serializers.OrderSerializer(
+            page_results, many=True, context=context
+        )
+        data = {"orders": serializer.data, "count": count, "total_pages": total_pages}
         return Response(data, status.HTTP_200_OK)
 
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def check_alerts(self, request):
-        wallet_hash = request.query_params.get('wallet_hash')
+        wallet_hash = request.query_params.get("wallet_hash")
         has_cashin_alerts = utils.check_has_cashin_alerts(wallet_hash)
-        return Response({'has_cashin_alerts': has_cashin_alerts}, status=200)
-    
-class PublicOrdersViewSet(
-    mixins.ListModelMixin, 
-    mixins.RetrieveModelMixin,
-    viewsets.GenericViewSet
-):
+        return Response({"has_cashin_alerts": has_cashin_alerts}, status=200)
 
+
+class PublicOrdersViewSet(
+    mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet
+):
     """
     A read-only public endpoint for orders with no sensitive data.
     """
+
     queryset = models.Order.objects.all()
     serializer_class = serializers.PublicOrderSerializer
     pagination_class = StandardResultsSetPagination
@@ -130,33 +142,40 @@ class PublicOrdersViewSet(
     authentication_classes = []
 
     def get_queryset(self):
-        wallet_hash = self.request.query_params.get('wallet_hash')
+        wallet_hash = self.request.query_params.get("wallet_hash")
 
         if not wallet_hash:
-            return models.Order.objects.none()  # Return an empty queryset if wallet_hash is not provided
-        
+            return (
+                models.Order.objects.none()
+            )  # Return an empty queryset if wallet_hash is not provided
+
         queryset = models.Order.objects.filter(
-            Q(owner__wallet_hash=wallet_hash) | 
-            Q(ad_snapshot__ad__owner__wallet_hash=wallet_hash)
+            Q(owner__wallet_hash=wallet_hash)
+            | Q(ad_snapshot__ad__owner__wallet_hash=wallet_hash)
         ).distinct()
 
         queryset = queryset.annotate(
             last_status=Subquery(
-                models.Status.objects.filter(order=OuterRef('pk')).order_by('-created_at').values('status')[:1]
+                models.Status.objects.filter(order=OuterRef("pk"))
+                .order_by("-created_at")
+                .values("status")[:1]
             )
         )
 
         queryset = queryset.filter(
-            Q(last_status__in=[
-                StatusType.CONFIRMED, 
-                StatusType.ESCROW_PENDING, 
-                StatusType.ESCROWED,
-                StatusType.PAID_PENDING,
-                StatusType.PAID
-            ])
+            Q(
+                last_status__in=[
+                    StatusType.CONFIRMED,
+                    StatusType.ESCROW_PENDING,
+                    StatusType.ESCROWED,
+                    StatusType.PAID_PENDING,
+                    StatusType.PAID,
+                ]
+            )
         )
-        
+
         return queryset
+
 
 class OrderViewSet(viewsets.GenericViewSet):
     authentication_classes = [TokenAuthentication]
@@ -168,39 +187,42 @@ class OrderViewSet(viewsets.GenericViewSet):
             order = self.get_queryset().get(pk=pk)
         except models.Order.DoesNotExist:
             raise Http404
-        
-        wallet_hash = request.headers.get('wallet_hash')
+
+        wallet_hash = request.headers.get("wallet_hash")
         if wallet_hash is None:
-            return Response({'error': 'wallet_hash is required'}, status=status.HTTP_400_BAD_REQUEST)
-        
-        serialized_order = serializers.OrderSerializer(order, context={ 'wallet_hash': wallet_hash }).data
-        
-        if serialized_order['status']['value'] == StatusType.APPEALED:
+            return Response(
+                {"error": "wallet_hash is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        serialized_order = serializers.OrderSerializer(
+            order, context={"wallet_hash": wallet_hash}
+        ).data
+
+        if serialized_order["status"]["value"] == StatusType.APPEALED:
             appeal = models.Appeal.objects.filter(order_id=order.id)
             if appeal.exists():
                 serialized_appeal = serializers.AppealSerializer(appeal.first()).data
-                serialized_order['appeal'] = serialized_appeal
+                serialized_order["appeal"] = serialized_appeal
         return Response(serialized_order, status=status.HTTP_200_OK)
 
     def list(self, request):
         wallet_hash = request.user.wallet_hash
         params = self.parse_params(request)
 
-        if params['status_type'] is None:
+        if params["status_type"] is None:
             return Response(
-                {'error': 'status_type is required'},
-                status=status.HTTP_400_BAD_REQUEST
+                {"error": "status_type is required"}, status=status.HTTP_400_BAD_REQUEST
             )
 
         try:
-            limit = int(params['limit'])
-            page = int(params['page'])
+            limit = int(params["limit"])
+            page = int(params["page"])
             if limit < 0:
-                raise ValidationError('limit must be a non-negative number')
+                raise ValidationError("limit must be a non-negative number")
             if page < 1:
-                raise ValidationError('invalid page number')
+                raise ValidationError("invalid page number")
         except (ValueError, ValidationError) as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
         queryset = models.Order.objects.all()
 
@@ -208,99 +230,118 @@ class OrderViewSet(viewsets.GenericViewSet):
         owned_orders = Q(owner__wallet_hash=wallet_hash)
 
         # fetches the orders that have ad ids owned by user
-        ad_orders = Q(ad_snapshot__ad__pk__in=list(
-                        # fetches the flat ids of ads owned by user
-                        models.Ad.objects.filter(
-                            owner__wallet_hash=wallet_hash
-                        ).values_list('id', flat=True)
-                    ))
+        ad_orders = Q(
+            ad_snapshot__ad__pk__in=list(
+                # fetches the flat ids of ads owned by user
+                models.Ad.objects.filter(owner__wallet_hash=wallet_hash).values_list(
+                    "id", flat=True
+                )
+            )
+        )
 
-        if params['owned'] == True:
+        if params["owned"] == True:
             queryset = queryset.filter(owned_orders)
-        elif params['owned'] == False:
+        elif params["owned"] == False:
             queryset = queryset.filter(ad_orders)
         else:
             queryset = queryset.filter(owned_orders | ad_orders)
 
         # filter by currency
-        if params['currency']:
-            queryset = queryset.filter(ad_snapshot__fiat_currency__symbol=params['currency'])
+        if params["currency"]:
+            queryset = queryset.filter(
+                ad_snapshot__fiat_currency__symbol=params["currency"]
+            )
 
         # filter or exclude orders based to their latest status
         completed_status = [
             StatusType.CANCELED,
             StatusType.RELEASED,
-            StatusType.REFUNDED
+            StatusType.REFUNDED,
         ]
-        last_status_subq = Status.objects.filter(
-            order=OuterRef('pk')
-        ).order_by('-created_at').values('status')[:1]
+        last_status_subq = (
+            Status.objects.filter(order=OuterRef("pk"))
+            .order_by("-created_at")
+            .values("status")[:1]
+        )
         queryset = queryset.annotate(last_status=Subquery(last_status_subq))
 
-        if params['status_type'] == 'COMPLETED':            
+        if params["status_type"] == "COMPLETED":
             queryset = queryset.filter(last_status__in=completed_status)
-        elif params['status_type'] == 'ONGOING':
+        elif params["status_type"] == "ONGOING":
             queryset = queryset.exclude(last_status__in=completed_status)
-        
-        if len(params['statuses']) > 0:
+
+        if len(params["statuses"]) > 0:
             # get the order's last status
-            last_status_subq = models.Status.objects.filter(order=OuterRef('id')).order_by('-created_at').values('status')[:1]
+            last_status_subq = (
+                models.Status.objects.filter(order=OuterRef("id"))
+                .order_by("-created_at")
+                .values("status")[:1]
+            )
             # check if the last status is a subset of filtered statuses
-            temp = queryset.annotate(
-                last_status=Subquery(last_status_subq)
-                ).annotate(
-                    is_in_filtered_status = Case(
-                        When(last_status__in=list(map(str, params['statuses'])), then=Value(True)),
-                        default=Value(False),
-                        output_field=BooleanField(),
-                    )                    
+            temp = queryset.annotate(last_status=Subquery(last_status_subq)).annotate(
+                is_in_filtered_status=Case(
+                    When(
+                        last_status__in=list(map(str, params["statuses"])),
+                        then=Value(True),
+                    ),
+                    default=Value(False),
+                    output_field=BooleanField(),
                 )
+            )
             queryset = temp.filter(is_in_filtered_status=True)
 
         # filters by ad payment types
-        if len(params['payment_types']) > 0:
-            payment_types = list(map(int, params['payment_types']))
-            queryset = queryset.filter(Q(ad_snapshot__payment_types__id__in=payment_types) | Q(ad_snapshot__payment_types=None)).distinct()
+        if len(params["payment_types"]) > 0:
+            payment_types = list(map(int, params["payment_types"]))
+            queryset = queryset.filter(
+                Q(ad_snapshot__payment_types__id__in=payment_types)
+                | Q(ad_snapshot__payment_types=None)
+            ).distinct()
 
         # filters by ad time limits
-        if len(params['time_limits']) > 0:
-            time_limits = list(map(int, params['time_limits']))
-            queryset = queryset.filter(ad_snapshot__appeal_cooldown_choice__in=time_limits).distinct()
+        if len(params["time_limits"]) > 0:
+            time_limits = list(map(int, params["time_limits"]))
+            queryset = queryset.filter(
+                ad_snapshot__appeal_cooldown_choice__in=time_limits
+            ).distinct()
 
         # filters by order trade type
-        if params['trade_type'] is not None:
-            queryset = queryset.exclude(Q(ad_snapshot__trade_type=params['trade_type']))
+        if params["trade_type"] is not None:
+            queryset = queryset.exclude(Q(ad_snapshot__trade_type=params["trade_type"]))
 
         # filter/exclude appealable orders
-        filter = not(params['appealable'] and params['not_appealable'] )
+        filter = not (params["appealable"] and params["not_appealable"])
         if filter is True:
-            if params['appealable'] is True:
+            if params["appealable"] is True:
                 queryset = queryset.filter(Q(appealable_at__isnull=False))
                 queryset = queryset.exclude(last_status=StatusType.APPEALED)
-            if params['not_appealable'] is True:
+            if params["not_appealable"] is True:
                 queryset = queryset.exclude(Q(appealable_at__isnull=False))
 
-        if params['sort_by'] == 'last_modified_at':
-            sort_field = 'last_modified_at'
-            if params['sort_type'] == 'descending':
-                sort_field = f'-{sort_field}'
-            last_status_created_at = models.Status.objects.filter(
-                order=OuterRef('pk')).order_by('-created_at').values('created_at')[:1]
+        if params["sort_by"] == "last_modified_at":
+            sort_field = "last_modified_at"
+            if params["sort_type"] == "descending":
+                sort_field = f"-{sort_field}"
+            last_status_created_at = (
+                models.Status.objects.filter(order=OuterRef("pk"))
+                .order_by("-created_at")
+                .values("created_at")[:1]
+            )
             queryset = queryset.annotate(
                 last_modified_at=Subquery(last_status_created_at)
             ).order_by(sort_field)
         else:
-            sort_field = 'created_at'
-            if (params['sort_type'] == 'descending'):
-                sort_field = f'-{sort_field}'
-            if params['status_type'] == 'ONGOING':
+            sort_field = "created_at"
+            if params["sort_type"] == "descending":
+                sort_field = f"-{sort_field}"
+            if params["status_type"] == "ONGOING":
                 queryset = queryset.order_by(sort_field)
-            if params['status_type'] == 'COMPLETED':
+            if params["status_type"] == "COMPLETED":
                 queryset = queryset.order_by(sort_field)
-                
+
         # search for orders with specific owner name
-        if params['query_name']:
-            queryset = queryset.filter(owner__name__icontains=params['query_name'])
+        if params["query_name"]:
+            queryset = queryset.filter(owner__name__icontains=params["query_name"])
 
         # Count total pages
         count = queryset.count()
@@ -310,40 +351,46 @@ class OrderViewSet(viewsets.GenericViewSet):
 
         # Splice queryset
         offset = (page - 1) * limit
-        page_results = queryset[offset:offset + limit]
+        page_results = queryset[offset : offset + limit]
 
-        context = { 'wallet_hash': wallet_hash }
-        serializer = serializers.OrderSerializer(page_results, many=True, context=context)
-        unread_count = models.OrderMember.objects.filter(Q(peer__wallet_hash=wallet_hash) & Q(read_at__isnull=True)).count()
+        context = {"wallet_hash": wallet_hash}
+        serializer = serializers.OrderSerializer(
+            page_results, many=True, context=context
+        )
+        unread_count = models.OrderMember.objects.filter(
+            Q(peer__wallet_hash=wallet_hash) & Q(read_at__isnull=True)
+        ).count()
         data = {
-            'orders': serializer.data,
-            'count': count,
-            'total_pages': total_pages,
-            'unread_count': unread_count
+            "orders": serializer.data,
+            "count": count,
+            "total_pages": total_pages,
+            "unread_count": unread_count,
         }
         return Response(data, status.HTTP_200_OK)
 
     def create(self, request):
         wallet_hash = request.user.wallet_hash
         try:
-            payment_method_ids = request.data.get('payment_methods', [])
-            is_cash_in = request.data.get('is_cash_in', False)
-            trade_amount = request.data.get('trade_amount')
+            payment_method_ids = request.data.get("payment_methods", [])
+            is_cash_in = request.data.get("is_cash_in", False)
+            trade_amount = request.data.get("trade_amount")
             if trade_amount == None or trade_amount == 0:
-                raise ValidationError('trade_amount field is required')
+                raise ValidationError("trade_amount field is required")
 
-            ad = models.Ad.objects.get(pk=request.data.get('ad'))
+            ad = models.Ad.objects.get(pk=request.data.get("ad"))
             owner = models.Peer.objects.get(wallet_hash=wallet_hash)
 
             # require payment methods if creating a SELL order
             if ad.trade_type == models.TradeType.BUY:
                 if len(payment_method_ids) == 0:
-                    raise ValidationError('payment_methods field is required for SELL orders')            
+                    raise ValidationError(
+                        "payment_methods field is required for SELL orders"
+                    )
                 self.check_payment_permissions(wallet_hash, payment_method_ids)
-            
+
             # check permissions
             self.check_create_permissions(wallet_hash, ad.id)
-        
+
             with transaction.atomic():
                 if is_cash_in:
                     self.require_singular_cashin_order(wallet_hash=wallet_hash)
@@ -352,17 +399,17 @@ class OrderViewSet(viewsets.GenericViewSet):
                 tracking_id = self.generate_tracking_id()
 
                 data = {
-                    'owner': owner.id,
-                    'ad_snapshot': snapshot.id,
-                    'payment_methods': payment_method_ids,
-                    'trade_amount': trade_amount,
-                    'is_cash_in': is_cash_in,
-                    'tracking_id': tracking_id
+                    "owner": owner.id,
+                    "ad_snapshot": snapshot.id,
+                    "payment_methods": payment_method_ids,
+                    "trade_amount": trade_amount,
+                    "is_cash_in": is_cash_in,
+                    "tracking_id": tracking_id,
                 }
                 serialized_order = serializers.WriteOrderSerializer(data=data)
                 serialized_order.is_valid(raise_exception=True)
                 order = serialized_order.save()
-                
+
                 self.set_expiration_date(order)
                 self.submit_order(ad=ad, order=order, wallet_hash=wallet_hash)
 
@@ -370,20 +417,30 @@ class OrderViewSet(viewsets.GenericViewSet):
                 self.mark_creator_as_read(order=order, members=members)
 
                 if order.is_cash_in:
-                    self.create_order_payment_methods(payment_method_ids=payment_method_ids, order=order)
+                    self.create_order_payment_methods(
+                        payment_method_ids=payment_method_ids, order=order
+                    )
 
                 self.update_ad_trade_amount(order=order)
-                serialized_status = self.confirm_order(wallet_hash=wallet_hash, order=order)
+                serialized_status = self.confirm_order(
+                    wallet_hash=wallet_hash, order=order
+                )
 
-                serialized_order = serializers.OrderSerializer(order, context={'wallet_hash': wallet_hash}).data    
+                serialized_order = serializers.OrderSerializer(
+                    order, context={"wallet_hash": wallet_hash}
+                ).data
                 response = {
-                    'success': True,
-                    'order': serialized_order,
-                    'status': serialized_status
+                    "success": True,
+                    "order": serialized_order,
+                    "status": serialized_status,
                 }
             return Response(response, status=status.HTTP_201_CREATED)
-        except (models.Ad.DoesNotExist, models.Peer.DoesNotExist, ValidationError) as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+        except (
+            models.Ad.DoesNotExist,
+            models.Peer.DoesNotExist,
+            ValidationError,
+        ) as err:
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
     def partial_update(self, request, pk):
         try:
@@ -392,18 +449,20 @@ class OrderViewSet(viewsets.GenericViewSet):
             raise Http404
 
         wallet_hash = request.user.wallet_hash
-        chat_session_ref = request.data.get('chat_session_ref')
+        chat_session_ref = request.data.get("chat_session_ref")
 
         if chat_session_ref:
             order.chat_session_ref = chat_session_ref
             order.save()
 
-        serialized_order = serializers.OrderSerializer(order, context={ 'wallet_hash': wallet_hash }).data
+        serialized_order = serializers.OrderSerializer(
+            order, context={"wallet_hash": wallet_hash}
+        ).data
         return Response(serialized_order, status=status.HTTP_200_OK)
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def members(self, request, pk):
-        if request.method == 'GET':
+        if request.method == "GET":
             try:
                 order = models.Order.objects.get(pk=pk)
                 members = [order.owner, order.ad_snapshot.ad.owner]
@@ -412,131 +471,179 @@ class OrderViewSet(viewsets.GenericViewSet):
 
                 member_info = []
                 for member in members:
-                    member_info.append({
-                        'id': member.id,
-                        'chat_identity_id': member.chat_identity_id,
-                        'public_key': member.public_key,
-                        'name': member.name,
-                        'address': member.address,
-                        'is_arbiter': isinstance(member, models.Arbiter)
-                    })
-                
+                    member_info.append(
+                        {
+                            "id": member.id,
+                            "chat_identity_id": member.chat_identity_id,
+                            "public_key": member.public_key,
+                            "name": member.name,
+                            "address": member.address,
+                            "is_arbiter": isinstance(member, models.Arbiter),
+                        }
+                    )
+
                 members = serializers.OrderMemberSerializer(member_info, many=True)
             except models.Order.DoesNotExist:
                 raise Http404
             except Exception as err:
-                return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+                return Response(
+                    {"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST
+                )
             return Response(members.data, status=status.HTTP_200_OK)
-        
-        if request.method == 'PATCH':
+
+        if request.method == "PATCH":
             wallet_hash = request.user.wallet_hash
-            member = models.OrderMember.objects.filter(Q(order__id=pk) & (Q(peer__wallet_hash=wallet_hash) | Q(arbiter__wallet_hash=wallet_hash)))
+            member = models.OrderMember.objects.filter(
+                Q(order__id=pk)
+                & (
+                    Q(peer__wallet_hash=wallet_hash)
+                    | Q(arbiter__wallet_hash=wallet_hash)
+                )
+            )
             if not member.exists():
-                return Response({'success': False, 'error': 'no such member'}, status=status.HTTP_400_BAD_REQUEST)
-            
+                return Response(
+                    {"success": False, "error": "no such member"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
             member = member.first()
             member.read_at = timezone.now()
             member.save()
-        
+
             if isinstance(request.user, models.Arbiter):
-                member_orders = models.OrderMember.objects.filter(Q(read_at__isnull=True) & Q(arbiter__wallet_hash=wallet_hash)).values_list('order', flat=True)
-                unread_count = models.Appeal.objects.filter(order__in=member_orders).count()
+                member_orders = models.OrderMember.objects.filter(
+                    Q(read_at__isnull=True) & Q(arbiter__wallet_hash=wallet_hash)
+                ).values_list("order", flat=True)
+                unread_count = models.Appeal.objects.filter(
+                    order__in=member_orders
+                ).count()
             else:
-                unread_count = models.OrderMember.objects.filter(Q(read_at__isnull=True) & Q(peer__wallet_hash=wallet_hash)).count()
-            
-            websocket.send_general_update({'type': WSGeneralMessageType.READ_ORDER.value, 'extra': { 'unread_count': unread_count }}, wallet_hash)
-            return Response({'success': True}, status=status.HTTP_200_OK)
-    
+                unread_count = models.OrderMember.objects.filter(
+                    Q(read_at__isnull=True) & Q(peer__wallet_hash=wallet_hash)
+                ).count()
+
+            websocket.send_general_update(
+                {
+                    "type": WSGeneralMessageType.READ_ORDER.value,
+                    "extra": {"unread_count": unread_count},
+                },
+                wallet_hash,
+            )
+            return Response({"success": True}, status=status.HTTP_200_OK)
+
     def parse_params(self, request_data):
         request = request_data
-        limit = request.query_params.get('limit', 0)
-        page = request.query_params.get('page', 1)
-        status_type = request.query_params.get('status_type')
-        currency = request.query_params.get('currency')
-        trade_type = request.query_params.get('trade_type')
-        statuses = request.query_params.getlist('status')
-        payment_types = request.query_params.getlist('payment_types')
-        time_limits = request.query_params.getlist('time_limits')
-        sort_by = request.query_params.get('sort_by')
-        sort_type = request.query_params.get('sort_type')
-        owned = request.query_params.get('owned')
-        appealable = request.query_params.get('appealable')
-        not_appealable = request.query_params.get('not_appealable')
-        query_name = request.query_params.get('query_name')
+        limit = request.query_params.get("limit", 0)
+        page = request.query_params.get("page", 1)
+        status_type = request.query_params.get("status_type")
+        currency = request.query_params.get("currency")
+        trade_type = request.query_params.get("trade_type")
+        statuses = request.query_params.getlist("status")
+        payment_types = request.query_params.getlist("payment_types")
+        time_limits = request.query_params.getlist("time_limits")
+        sort_by = request.query_params.get("sort_by")
+        sort_type = request.query_params.get("sort_type")
+        owned = request.query_params.get("owned")
+        appealable = request.query_params.get("appealable")
+        not_appealable = request.query_params.get("not_appealable")
+        query_name = request.query_params.get("query_name")
 
         if owned is not None:
-            owned = owned == 'true'
+            owned = owned == "true"
         if appealable is not None:
-            appealable = appealable == 'true'
+            appealable = appealable == "true"
         if not_appealable is not None:
-            not_appealable = not_appealable == 'true'
+            not_appealable = not_appealable == "true"
 
         return {
-            'limit': limit,
-            'page': page,
-            'status_type': status_type,
-            'currency': currency,
-            'trade_type': trade_type,
-            'statuses': statuses,
-            'payment_types': payment_types,
-            'time_limits': time_limits,
-            'sort_by': sort_by,
-            'sort_type': sort_type,
-            'owned': owned,
-            'appealable': appealable,
-            'not_appealable': not_appealable,
-            'query_name': query_name
+            "limit": limit,
+            "page": page,
+            "status_type": status_type,
+            "currency": currency,
+            "trade_type": trade_type,
+            "statuses": statuses,
+            "payment_types": payment_types,
+            "time_limits": time_limits,
+            "sort_by": sort_by,
+            "sort_type": sort_type,
+            "owned": owned,
+            "appealable": appealable,
+            "not_appealable": not_appealable,
+            "query_name": query_name,
         }
-    
+
     def generate_tracking_id(self):
-        ''' PEO[year][month][day]-[order_count_today] e.g. PEO20211201-0001 '''
+        """PEO[year][month][day]-[order_count_today] e.g. PEO20211201-0001"""
         today = datetime.today()
         today_midnight = datetime.combine(today, time.min)
         next_day_midnight = datetime.combine(today + timedelta(days=1), time.min)
-        order_count = models.Order.objects.filter(created_at__gte=today_midnight, created_at__lt=next_day_midnight).count()
-        tracking_id = f'PEO{today.year}{str(today.month).zfill(2)}{str(today.day).zfill(2)}-{str(order_count).zfill(4)}'
+        order_count = models.Order.objects.filter(
+            created_at__gte=today_midnight, created_at__lt=next_day_midnight
+        ).count()
+        tracking_id = f"PEO{today.year}{str(today.month).zfill(2)}{str(today.day).zfill(2)}-{str(order_count).zfill(4)}"
         return tracking_id
-    
+
     def check_create_permissions(self, wallet_hash, pk):
-        '''
+        """
         - Arbiters are not allowed to create orders
         - Ad owners are not allowed to create orders for their own ads
-        '''
+        """
         # check if arbiter
         is_arbiter = models.Arbiter.objects.filter(wallet_hash=wallet_hash).exists()
-        if is_arbiter: raise ValidationError('Arbiter cannot create orders')
+        if is_arbiter:
+            raise ValidationError("Arbiter cannot create orders")
 
         # check if ad owner
-        is_ad_owner = models.Ad.objects.filter(pk=pk, owner__wallet_hash=wallet_hash).exists()
-        if is_ad_owner: raise ValidationError('Ad owner cannot create order for this ad')
+        is_ad_owner = models.Ad.objects.filter(
+            pk=pk, owner__wallet_hash=wallet_hash
+        ).exists()
+        if is_ad_owner:
+            raise ValidationError("Ad owner cannot create order for this ad")
 
     def check_payment_permissions(self, wallet_hash, payment_method_ids: List[int]):
-        ''' Validates if peer owns the payment methods '''
-        owned_payment_methods = models.PaymentMethod.objects.filter(Q(owner__wallet_hash=wallet_hash) & Q(id__in=payment_method_ids))
-        if len(payment_method_ids) != owned_payment_methods.count():
-            raise ValidationError(f'Invalid payment method(s). Expected {len(payment_method_ids)} owned payment methods, got {owned_payment_methods.count()}.')
-    
-    def cancellable_cash_in_orders(self, wallet_hash):
-        queryset = models.Order.objects.filter(Q(owner__wallet_hash=wallet_hash) & Q(is_cash_in=True))
-
-        latest_status = models.Status.objects.filter(order__id=OuterRef('pk')).order_by('-id')
-        queryset = queryset.annotate(
-            latest_status = Subquery(latest_status.values('status')[:1], output_field=CharField())
+        """Validates if peer owns the payment methods"""
+        owned_payment_methods = models.PaymentMethod.objects.filter(
+            Q(owner__wallet_hash=wallet_hash) & Q(id__in=payment_method_ids)
         )
-        queryset = queryset.filter(Q(latest_status=StatusType.SUBMITTED) | Q(latest_status=StatusType.CONFIRMED)).values_list('id', flat=True)
+        if len(payment_method_ids) != owned_payment_methods.count():
+            raise ValidationError(
+                f"Invalid payment method(s). Expected {len(payment_method_ids)} owned payment methods, got {owned_payment_methods.count()}."
+            )
+
+    def cancellable_cash_in_orders(self, wallet_hash):
+        queryset = models.Order.objects.filter(
+            Q(owner__wallet_hash=wallet_hash) & Q(is_cash_in=True)
+        )
+
+        latest_status = models.Status.objects.filter(order__id=OuterRef("pk")).order_by(
+            "-id"
+        )
+        queryset = queryset.annotate(
+            latest_status=Subquery(
+                latest_status.values("status")[:1], output_field=CharField()
+            )
+        )
+        queryset = queryset.filter(
+            Q(latest_status=StatusType.SUBMITTED)
+            | Q(latest_status=StatusType.CONFIRMED)
+        ).values_list("id", flat=True)
         return queryset
 
     def update_ad_trade_amount(self, order=None):
         # Decrease the Ad's trade amount and limits
         ad = order.ad_snapshot.ad
         if order.ad_snapshot.trade_limits_in_fiat:
-            order_amount_fiat = bch_to_fiat(satoshi_to_bch(order.trade_amount), order.ad_snapshot.price)
+            order_amount_fiat = bch_to_fiat(
+                satoshi_to_bch(order.trade_amount), order.ad_snapshot.price
+            )
             ad_quantity_fiat = Decimal(order.ad_snapshot.trade_amount_fiat)
             new_ad_quantity_fiat = ad_quantity_fiat - order_amount_fiat
-            
+
             if new_ad_quantity_fiat < 0:
-                raise ValidationError('order amount exceeds ad remaining trade quantity')
-            
+                raise ValidationError(
+                    "order amount exceeds ad remaining trade quantity"
+                )
+
             ad.trade_amount_fiat = new_ad_quantity_fiat
             if ad.trade_amount_fiat < ad.trade_ceiling_fiat:
                 ad.trade_ceiling_fiat = new_ad_quantity_fiat
@@ -544,10 +651,12 @@ class OrderViewSet(viewsets.GenericViewSet):
             order_amount_sats = order.trade_amount
             ad_quantity_sats = order.ad_snapshot.ad.trade_amount_sats
             new_ad_quantity_sats = ad_quantity_sats - order_amount_sats
-            
+
             if new_ad_quantity_sats < 0:
-                raise ValidationError('order amount exceeds ad remaining trade quantity')
-            
+                raise ValidationError(
+                    "order amount exceeds ad remaining trade quantity"
+                )
+
             ad.trade_amount_sats = new_ad_quantity_sats
             if ad.trade_amount_sats < ad.trade_ceiling_sats:
                 ad.trade_ceiling_sats = new_ad_quantity_sats
@@ -556,38 +665,40 @@ class OrderViewSet(viewsets.GenericViewSet):
     def get_market_price(self, currency):
         market_price = models.MarketPrice.objects.filter(currency=currency)
         if not market_price.exists():
-            raise ValidationError(f'market price for currency {currency} does not exist.')
+            raise ValidationError(
+                f"market price for currency {currency} does not exist."
+            )
         return market_price.first()
-    
+
     def snapshot_ad(self, ad):
         # query market price for ad fiat currency
         market_price = self.get_market_price(ad.fiat_currency.symbol)
 
         ad_snapshot = models.AdSnapshot(
-            ad = ad,
-            trade_type = ad.trade_type,
-            price_type = ad.price_type,
-            fiat_currency = ad.fiat_currency,
-            crypto_currency = ad.crypto_currency,
-            fixed_price = ad.fixed_price,
-            floating_price = ad.floating_price,
-            market_price = market_price.price,
-            trade_floor_sats = ad.trade_floor_sats,
-            trade_ceiling_sats = ad.trade_ceiling_sats,
-            trade_amount_sats = ad.trade_amount_sats,
-            trade_floor_fiat = ad.trade_floor_fiat,
-            trade_ceiling_fiat = ad.trade_ceiling_fiat,
-            trade_amount_fiat = ad.trade_amount_fiat,
-            appeal_cooldown_choice = ad.appeal_cooldown_choice,
-            trade_amount_in_fiat = ad.trade_amount_in_fiat,
-            trade_limits_in_fiat = ad.trade_limits_in_fiat
+            ad=ad,
+            trade_type=ad.trade_type,
+            price_type=ad.price_type,
+            fiat_currency=ad.fiat_currency,
+            crypto_currency=ad.crypto_currency,
+            fixed_price=ad.fixed_price,
+            floating_price=ad.floating_price,
+            market_price=market_price.price,
+            trade_floor_sats=ad.trade_floor_sats,
+            trade_ceiling_sats=ad.trade_ceiling_sats,
+            trade_amount_sats=ad.trade_amount_sats,
+            trade_floor_fiat=ad.trade_floor_fiat,
+            trade_ceiling_fiat=ad.trade_ceiling_fiat,
+            trade_amount_fiat=ad.trade_amount_fiat,
+            appeal_cooldown_choice=ad.appeal_cooldown_choice,
+            trade_amount_in_fiat=ad.trade_amount_in_fiat,
+            trade_limits_in_fiat=ad.trade_limits_in_fiat,
         )
         ad_snapshot.save()
         ad_payment_methods = ad.payment_methods.all()
         ad_payment_types = [pm.payment_type for pm in ad_payment_methods]
         ad_snapshot.payment_types.set(ad_payment_types)
         return ad_snapshot
-    
+
     def set_expiration_date(self, order):
         expiration = order.created_at + timedelta(hours=24)
         if order.is_cash_in:
@@ -596,17 +707,15 @@ class OrderViewSet(viewsets.GenericViewSet):
         order.save()
 
     def create_status(self, order=None, status_type=None, creator=None):
-        submitted_status = serializers.StatusSerializer(data={
-            'status': status_type, 
-            'order': order.id,
-            'created_by': creator
-        })
+        submitted_status = serializers.StatusSerializer(
+            data={"status": status_type, "order": order.id, "created_by": creator}
+        )
         submitted_status.is_valid(raise_exception=True)
         submitted_status = submitted_status.save()
         return submitted_status
-    
+
     def create_members(self, snapshot=None, order=None):
-       
+
         seller, buyer = None, None
         if snapshot.trade_type == models.TradeType.SELL:
             seller = snapshot.ad.owner
@@ -614,27 +723,28 @@ class OrderViewSet(viewsets.GenericViewSet):
         else:
             seller = order.owner
             buyer = snapshot.ad.owner
-        
-        seller_member = models.OrderMember.objects.create(order=order, peer=seller, type=models.OrderMember.MemberType.SELLER)
-        buyer_member = models.OrderMember.objects.create(order=order, peer=buyer, type=models.OrderMember.MemberType.BUYER)
-        
-        return {
-            'seller_member': seller_member,
-            'buyer_member': buyer_member
-        }
-    
+
+        seller_member = models.OrderMember.objects.create(
+            order=order, peer=seller, type=models.OrderMember.MemberType.SELLER
+        )
+        buyer_member = models.OrderMember.objects.create(
+            order=order, peer=buyer, type=models.OrderMember.MemberType.BUYER
+        )
+
+        return {"seller_member": seller_member, "buyer_member": buyer_member}
+
     def mark_creator_as_read(self, order=None, members=None):
         if members == None or order == None:
-            raise ValidationError('mark_creator_as_read: has empty order or members')
-        
-        seller = members.get('seller_member')
-        buyer = members.get('buyer_member')
+            raise ValidationError("mark_creator_as_read: has empty order or members")
+
+        seller = members.get("seller_member")
+        buyer = members.get("buyer_member")
 
         # Mark order creator member as already read
         if seller.peer.wallet_hash == order.owner.wallet_hash:
             seller.read_at = timezone.now()
             seller.save()
-        
+
         if buyer.peer.wallet_hash == order.owner.wallet_hash:
             buyer.read_at = timezone.now()
             buyer.save()
@@ -645,76 +755,93 @@ class OrderViewSet(viewsets.GenericViewSet):
             data = {
                 "order": order.id,
                 "payment_method": payment_method.id,
-                "payment_type": payment_method.payment_type.id
+                "payment_type": payment_method.payment_type.id,
             }
             order_method = serializers.OrderPaymentSerializer(data=data)
             if order_method.is_valid():
                 order_method.save()
-    
+
     def require_singular_cashin_order(self, wallet_hash=None):
         cancellable_cashin_orders = self.cancellable_cash_in_orders(wallet_hash)
         if cancellable_cashin_orders.count() > 0:
-            raise ValidationError({ 'pending_orders': cancellable_cashin_orders })
-    
+            raise ValidationError({"pending_orders": cancellable_cashin_orders})
+
     def notify_ad_owner_channel(self, ad=None, order=None):
-        unread_count = models.OrderMember.objects.filter(Q(read_at__isnull=True) & Q(peer__wallet_hash=ad.owner.wallet_hash)).count()
-        serialized_order = serializers.OrderSerializer(order, context={'wallet_hash': ad.owner.wallet_hash})
-        websocket.send_general_update({
-            'type': WSGeneralMessageType.NEW_ORDER.value,
-            'extra': {
-                'order': serialized_order.data,
-                'unread_count': unread_count
-            }
-        }, ad.owner.wallet_hash)
+        unread_count = models.OrderMember.objects.filter(
+            Q(read_at__isnull=True) & Q(peer__wallet_hash=ad.owner.wallet_hash)
+        ).count()
+        serialized_order = serializers.OrderSerializer(
+            order, context={"wallet_hash": ad.owner.wallet_hash}
+        )
+        websocket.send_general_update(
+            {
+                "type": WSGeneralMessageType.NEW_ORDER.value,
+                "extra": {"order": serialized_order.data, "unread_count": unread_count},
+            },
+            ad.owner.wallet_hash,
+        )
 
     def submit_order(self, ad=None, order=None, wallet_hash=None):
-        status = self.create_status(order=order, status_type=StatusType.SUBMITTED, creator=wallet_hash)   
+        status = self.create_status(
+            order=order, status_type=StatusType.SUBMITTED, creator=wallet_hash
+        )
         serialized_status = serializers.StatusReadSerializer(status)
 
-        send_push_notification([ad.owner.wallet_hash], "Received a new order", extra={'order_id': order.id})
+        send_push_notification(
+            [ad.owner.wallet_hash], "Received a new order", extra={"order_id": order.id}
+        )
         self.notify_ad_owner_channel(ad=ad, order=order)
 
         return serialized_status.data
 
     def confirm_order(self, order=None, wallet_hash=None):
-        status = self.create_status(order=order, status_type=StatusType.CONFIRMED, creator=wallet_hash)   
+        status = self.create_status(
+            order=order, status_type=StatusType.CONFIRMED, creator=wallet_hash
+        )
         serialized_status = serializers.StatusReadSerializer(status)
 
-        websocket.send_order_update({'success': True, 'status': serialized_status.data}, order.id)
+        websocket.send_order_update(
+            {"success": True, "status": serialized_status.data}, order.id
+        )
         if order.is_cash_in:
-            websocket.send_cashin_order_alert({'type': 'ORDER_STATUS_UPDATED', 'order': order.id}, order.owner.wallet_hash)
-        
+            websocket.send_cashin_order_alert(
+                {"type": "ORDER_STATUS_UPDATED", "order": order.id},
+                order.owner.wallet_hash,
+            )
+
         send_push_notification(
             [order.owner.wallet_hash],
-            f'Order #{order.id} confirmed',
-            extra={'order_id': order.id}
+            f"Order #{order.id} confirmed",
+            extra={"order_id": order.id},
         )
         return serialized_status.data
 
-        
+
 class OrderStatusViewSet(viewsets.GenericViewSet):
     authentication_classes = [TokenAuthentication]
     permission_classes = [RampP2PIsAuthenticated]
     serializer_class = serializers.OrderSerializer
     queryset = models.Order.objects.all()
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def list_status(self, request, pk):
-        queryset = Status.objects.filter(order__id=pk).order_by('-created_at')
+        queryset = Status.objects.filter(order__id=pk).order_by("-created_at")
         serializer = serializers.StatusSerializer(queryset, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @action(detail=True, methods=['patch'])
+    @action(detail=True, methods=["patch"])
     def read_status(self, request, pk):
         try:
             order = models.Order.objects.get(id=pk)
-            member = self._check_status_edit_permissions(order, request.user.wallet_hash)
+            member = self._check_status_edit_permissions(
+                order, request.user.wallet_hash
+            )
             statuses = models.Status.objects.filter(order__id=pk)
 
-            status_id = request.data.get('status_id')
+            status_id = request.data.get("status_id")
             if status_id:
                 statuses = statuses.filter(id=status_id)
-                
+
             for status_obj in statuses:
                 if member.type == models.OrderMember.MemberType.SELLER:
                     status_obj.seller_read_at = timezone.now()
@@ -723,12 +850,12 @@ class OrderStatusViewSet(viewsets.GenericViewSet):
                 status_obj.save()
             return Response(status=status.HTTP_200_OK)
         except (ValidationError, models.Order.DoesNotExist) as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
-    
-    @action(detail=False, methods=['patch'])
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=False, methods=["patch"])
     def read_order_status(self, request):
         wallet_hash = request.user.wallet_hash
-        order_ids = request.data.get('order_ids', [])
+        order_ids = request.data.get("order_ids", [])
         statuses = models.Status.objects.filter(order__id__in=order_ids)
         for status in statuses:
             if not status.buyer_read_at:
@@ -736,51 +863,66 @@ class OrderStatusViewSet(viewsets.GenericViewSet):
                 status.save()
 
         has_cashin_alerts = utils.check_has_cashin_alerts(wallet_hash)
-        return Response({'has_cashin_alerts': has_cashin_alerts}, status=200)
-    
-    @action(detail=True, methods=['post'])
+        return Response({"has_cashin_alerts": has_cashin_alerts}, status=200)
+
+    @action(detail=True, methods=["post"])
     def confirm(self, request, pk):
         wallet_hash = request.user.wallet_hash
         try:
-            with transaction.atomic():                
+            with transaction.atomic():
                 validate_status(pk, StatusType.SUBMITTED)
                 validate_status_inst_count(StatusType.CONFIRMED, pk)
                 validate_status_progression(StatusType.CONFIRMED, pk)
 
                 order = models.Order.objects.get(pk=pk)
                 if order.expires_at and order.expires_at < timezone.now():
-                    raise ValidationError('Cannot confirm expired order')
-                
+                    raise ValidationError("Cannot confirm expired order")
+
                 order.save()
 
-        except (ValidationError, IntegrityError, models.Order.DoesNotExist, models.Ad.DoesNotExist) as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
-        
-        serialized_status = serializers.StatusSerializer(data={
-            'status': StatusType.CONFIRMED,
-            'order': pk,
-            'created_by': wallet_hash
-        })
+        except (
+            ValidationError,
+            IntegrityError,
+            models.Order.DoesNotExist,
+            models.Ad.DoesNotExist,
+        ) as err:
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+        serialized_status = serializers.StatusSerializer(
+            data={
+                "status": StatusType.CONFIRMED,
+                "order": pk,
+                "created_by": wallet_hash,
+            }
+        )
 
         if not serialized_status.is_valid():
-            return Response(serialized_status.errors, status=status.HTTP_400_BAD_REQUEST)
-        
+            return Response(
+                serialized_status.errors, status=status.HTTP_400_BAD_REQUEST
+            )
+
         serialized_status = serializers.StatusReadSerializer(serialized_status.save())
-        
+
         # send websocket notification
-        websocket.send_order_update({'success': True, 'status': serialized_status.data}, pk)
+        websocket.send_order_update(
+            {"success": True, "status": serialized_status.data}, pk
+        )
         if order.is_cash_in:
-            websocket.send_cashin_order_alert({'type': 'ORDER_STATUS_UPDATED', 'order': pk}, order.owner.wallet_hash)
-        
+            websocket.send_cashin_order_alert(
+                {"type": "ORDER_STATUS_UPDATED", "order": pk}, order.owner.wallet_hash
+            )
+
         # send push notification
-        message = f'Order #{order.id} confirmed'
-        send_push_notification([order.owner.wallet_hash], message, extra={'order_id': order.id})
-        
+        message = f"Order #{order.id} confirmed"
+        send_push_notification(
+            [order.owner.wallet_hash], message, extra={"order_id": order.id}
+        )
+
         return Response(serialized_status.data, status=status.HTTP_200_OK)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def cancel(self, request, pk):
-        '''Cancels an order. Is callable by the order or ad owner.'''
+        """Cancels an order. Is callable by the order or ad owner."""
 
         wallet_hash = request.user.wallet_hash
 
@@ -789,18 +931,20 @@ class OrderStatusViewSet(viewsets.GenericViewSet):
             order_owner = order.owner.wallet_hash
             ad_owner = order.ad_snapshot.ad.owner.wallet_hash
             if wallet_hash != order_owner and wallet_hash != ad_owner:
-                raise ValidationError('Caller must be order or ad owner')
+                raise ValidationError("Caller must be order or ad owner")
 
             validate_status_inst_count(StatusType.CANCELED, pk)
             validate_status_progression(StatusType.CANCELED, pk)
 
             with transaction.atomic():
                 # Create CANCELED status for order
-                serializer = serializers.StatusSerializer(data={
-                    'status': StatusType.CANCELED, 
-                    'order': pk,
-                    'created_by': wallet_hash
-                })
+                serializer = serializers.StatusSerializer(
+                    data={
+                        "status": StatusType.CANCELED,
+                        "order": pk,
+                        "created_by": wallet_hash,
+                    }
+                )
                 if not serializer.is_valid():
                     raise ValidationError(serializer.errors)
                 serialized_status = serializers.StatusReadSerializer(serializer.save())
@@ -815,25 +959,34 @@ class OrderStatusViewSet(viewsets.GenericViewSet):
                 if counterparty.wallet_hash == wallet_hash:
                     counterparty = order.get_seller()
 
-                send_push_notification([counterparty.wallet_hash], f"Order #{order.id} cancelled", extra={'order_id': order.id})
+                send_push_notification(
+                    [counterparty.wallet_hash],
+                    f"Order #{order.id} cancelled",
+                    extra={"order_id": order.id},
+                )
 
                 # Send WebSocket update
-                websocket.send_order_update({'success' : True, 'status': serialized_status.data}, pk)
+                websocket.send_order_update(
+                    {"success": True, "status": serialized_status.data}, pk
+                )
                 if order.is_cash_in:
-                    websocket.send_cashin_order_alert({'type': 'ORDER_STATUS_UPDATED', 'order': pk}, order.owner.wallet_hash)
+                    websocket.send_cashin_order_alert(
+                        {"type": "ORDER_STATUS_UPDATED", "order": pk},
+                        order.owner.wallet_hash,
+                    )
 
         except ValidationError as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
-        return Response(serialized_status.data, status=status.HTTP_200_OK)        
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(serialized_status.data, status=status.HTTP_200_OK)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def pending_escrow(self, request, pk):
-        '''Creates a status ESCROW_PENDING for a given order. Callable only by the order's seller.'''
+        """Creates a status ESCROW_PENDING for a given order. Callable only by the order's seller."""
 
         wallet_hash = request.user.wallet_hash
         try:
-            order = models.Order.objects.get(pk=pk)        
-            
+            order = models.Order.objects.get(pk=pk)
+
             # Require user is seller
             seller = None
             if order.ad_snapshot.trade_type == models.TradeType.SELL:
@@ -841,45 +994,54 @@ class OrderStatusViewSet(viewsets.GenericViewSet):
             else:
                 seller = order.owner
             if wallet_hash != seller.wallet_hash:
-                raise ValidationError('Caller must be seller.')
+                raise ValidationError("Caller must be seller.")
 
             validate_status(pk, StatusType.CONFIRMED)
             validate_status_inst_count(StatusType.ESCROW_PENDING, pk)
             validate_status_progression(StatusType.ESCROW_PENDING, pk)
 
             contract = models.Contract.objects.get(order__id=pk)
-            
+
             # Create ESCROW_PENDING status for order
-            status_serializer = serializers.StatusSerializer(data={
-                'status': StatusType.ESCROW_PENDING, 
-                'order': pk,
-                'created_by': wallet_hash
-            })
+            status_serializer = serializers.StatusSerializer(
+                data={
+                    "status": StatusType.ESCROW_PENDING,
+                    "order": pk,
+                    "created_by": wallet_hash,
+                }
+            )
             if status_serializer.is_valid():
-                status_serializer = serializers.StatusReadSerializer(status_serializer.save())
-            else: 
+                status_serializer = serializers.StatusReadSerializer(
+                    status_serializer.save()
+                )
+            else:
                 raise ValidationError(f"Encountered error saving status for order#{pk}")
 
             # Create ESCROW transaction
-            transaction, _ = models.Transaction.objects.get_or_create(contract=contract, action=models.Transaction.ActionType.ESCROW)
+            transaction, _ = models.Transaction.objects.get_or_create(
+                contract=contract, action=models.Transaction.ActionType.ESCROW
+            )
 
             # Notify order WebSocket subscribers
             websocket_msg = {
-                'success' : True,
-                'status': status_serializer.data,
-                'transaction': serializers.TransactionSerializer(transaction).data
+                "success": True,
+                "status": status_serializer.data,
+                "transaction": serializers.TransactionSerializer(transaction).data,
             }
             websocket.send_order_update(websocket_msg, pk)
             if order.is_cash_in:
-                websocket.send_cashin_order_alert({'type': 'ORDER_STATUS_UPDATED', 'order': pk}, order.owner.wallet_hash)
+                websocket.send_cashin_order_alert(
+                    {"type": "ORDER_STATUS_UPDATED", "order": pk},
+                    order.owner.wallet_hash,
+                )
 
             response = websocket_msg
         except (ValidationError, IntegrityError, models.Contract.DoesNotExist) as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response(response, status=status.HTTP_200_OK)  
+        return Response(response, status=status.HTTP_200_OK)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def buyer_confirm_payment(self, request, pk):
         wallet_hash = request.user.wallet_hash
         try:
@@ -893,7 +1055,7 @@ class OrderStatusViewSet(viewsets.GenericViewSet):
                 buyer = order.ad_snapshot.ad.owner
 
             if wallet_hash != buyer.wallet_hash:
-                raise ValidationError('Caller must be buyer')
+                raise ValidationError("Caller must be buyer")
 
             validate_status_inst_count(StatusType.PAID_PENDING, pk)
             validate_status_progression(StatusType.PAID_PENDING, pk)
@@ -901,61 +1063,75 @@ class OrderStatusViewSet(viewsets.GenericViewSet):
             response = {}
             order_payment_methods = []
             if not order.is_cash_in:
-                '''Require selected payment methods if order is not cash-in.
-                Cash-in orders already have payment methods selected on order creation'''
+                """Require selected payment methods if order is not cash-in.
+                Cash-in orders already have payment methods selected on order creation"""
 
-                payment_method_ids = request.data.get('payment_methods')
+                payment_method_ids = request.data.get("payment_methods")
                 if payment_method_ids is None or len(payment_method_ids) == 0:
-                    raise ValidationError('Field payment_methods is required')
-                
-                # Update order payment methods to selected payment methods
-                payment_methods = models.PaymentMethod.objects.filter(id__in=payment_method_ids)
-                order.payment_methods.add(*payment_methods)
-                order.save() 
+                    raise ValidationError("Field payment_methods is required")
 
-                # Create order-specific payment methods
+                # Update order payment methods to selected payment methods
+                payment_methods = models.PaymentMethod.objects.filter(
+                    id__in=payment_method_ids
+                )
+                order.payment_methods.add(*payment_methods)
+                order.save()
+
+                # Get or create order-specific payment methods
                 for payment_method in payment_methods:
-                    data = {
-                        "order": order.id,
-                        "payment_method": payment_method.id,
-                        "payment_type": payment_method.payment_type.id
-                    }
-                    order_method = serializers.OrderPaymentSerializer(data=data)
-                    if order_method.is_valid():
-                        order_payment_methods.append(order_method.save())
-                order_payment_methods = serializers.OrderPaymentSerializer(order_payment_methods, many=True)
+                    order_payment, _ = models.OrderPayment.objects.get_or_create(
+                        order=order,
+                        payment_method=payment_method,
+                        defaults={"payment_type": payment_method.payment_type},
+                    )
+                    order_payment_methods.append(order_payment)
+                order_payment_methods = serializers.OrderPaymentSerializer(
+                    order_payment_methods, many=True
+                )
             else:
                 order_methods = models.OrderPayment.objects.filter(order__id=order.id)
                 if order_methods.exists():
-                    order_payment_methods = serializers.OrderPaymentSerializer(order_methods, many=True)
-            
+                    order_payment_methods = serializers.OrderPaymentSerializer(
+                        order_methods, many=True
+                    )
+
             response["order_payment_methods"] = order_payment_methods.data
 
-            context = { 'wallet_hash': wallet_hash }
+            context = {"wallet_hash": wallet_hash}
             serialized_order = serializers.OrderSerializer(order, context=context)
             response["order"] = serialized_order.data
-            
+
             # Create PAID_PENDING status for order
-            serialized_status = serializers.StatusSerializer(data={'status': StatusType.PAID_PENDING, 'order': pk})
-            if not serialized_status.is_valid():            
+            serialized_status = serializers.StatusSerializer(
+                data={"status": StatusType.PAID_PENDING, "order": pk}
+            )
+            if not serialized_status.is_valid():
                 raise ValidationError(serialized_status.errors)
-            
-            send_push_notification([order.get_seller().wallet_hash], f"Order #{order.id} payment pending confirmation", extra={'order_id': order.id})
-            
-            serialized_status = serializers.StatusReadSerializer(serialized_status.save())
-            websocket.send_order_update({'success' : True, 'status': serialized_status.data}, pk)
+
+            send_push_notification(
+                [order.get_seller().wallet_hash],
+                f"Order #{order.id} payment pending confirmation",
+                extra={"order_id": order.id},
+            )
+
+            serialized_status = serializers.StatusReadSerializer(
+                serialized_status.save()
+            )
+            websocket.send_order_update(
+                {"success": True, "status": serialized_status.data}, pk
+            )
             response["status"] = serialized_status.data
             return Response(response, status=status.HTTP_200_OK)
 
         except (ValidationError, models.Order.DoesNotExist) as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
-    
-    @action(detail=True, methods=['post'])
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=True, methods=["post"])
     def seller_confirm_payment(self, request, pk):
         wallet_hash = request.user.wallet_hash
         try:
             order = models.Order.objects.get(pk=pk)
-            
+
             # Require that user is seller
             seller = None
             if order.ad_snapshot.trade_type == models.TradeType.SELL:
@@ -963,40 +1139,47 @@ class OrderStatusViewSet(viewsets.GenericViewSet):
             else:
                 seller = order.owner
             if wallet_hash != seller.wallet_hash:
-                raise ValidationError('Caller must be seller')
-            
+                raise ValidationError("Caller must be seller")
+
             validate_status_inst_count(StatusType.PAID, pk)
             validate_status_progression(StatusType.PAID, pk)
 
             # Create PAID status for order
-            serialized_status = serializers.StatusSerializer(data={
-                'status': StatusType.PAID, 
-                'order': pk,
-                'created_by': wallet_hash
-            })
+            serialized_status = serializers.StatusSerializer(
+                data={"status": StatusType.PAID, "order": pk, "created_by": wallet_hash}
+            )
             if not serialized_status.is_valid():
                 raise ValidationError(serialized_status.errors)
-            serialized_status = serializers.StatusReadSerializer(serialized_status.save())
+            serialized_status = serializers.StatusReadSerializer(
+                serialized_status.save()
+            )
 
             # Create RELEASE transaction record for order contract
             contract = models.Contract.objects.get(order__id=pk)
-            _, _ = models.Transaction.objects.get_or_create(contract=contract, action=models.Transaction.ActionType.RELEASE)
+            _, _ = models.Transaction.objects.get_or_create(
+                contract=contract, action=models.Transaction.ActionType.RELEASE
+            )
 
             # Send push notif and WebSocket update
-            send_push_notification([order.get_buyer().wallet_hash], f"Order #{order.id} payment confirmed", extra={'order_id': order.id})
-            websocket.send_order_update({'success' : True, 'status': serialized_status.data}, pk)
+            send_push_notification(
+                [order.get_buyer().wallet_hash],
+                f"Order #{order.id} payment confirmed",
+                extra={"order_id": order.id},
+            )
+            websocket.send_order_update(
+                {"success": True, "status": serialized_status.data}, pk
+            )
             return Response(serialized_status.data, status=status.HTTP_200_OK)
 
         except (ValidationError, models.Order.DoesNotExist) as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
-    
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
     def _check_status_edit_permissions(self, order, wallet_hash):
-        '''Throws an error if wallet_hash is not a participant of status's order'''
-        
+        """Throws an error if wallet_hash is not a participant of status's order"""
+
         members = order.get_members()
-        if wallet_hash == members['seller'].peer.wallet_hash:
-            return members['seller']
-        if wallet_hash == members['buyer'].peer.wallet_hash:
-            return members['buyer']
-        raise ValidationError('User not allowed to perform this action')
-    
+        if wallet_hash == members["seller"].peer.wallet_hash:
+            return members["seller"]
+        if wallet_hash == members["buyer"].peer.wallet_hash:
+            return members["buyer"]
+        raise ValidationError("User not allowed to perform this action")

--- a/rampp2p/views/view_payment.py
+++ b/rampp2p/views/view_payment.py
@@ -271,26 +271,30 @@ class OrderPaymentViewSet(viewsets.GenericViewSet):
             if image_file is None:
                 raise ValidationError("image is required")
 
-            order = models.Order.objects.get(pk=order_id)
-            payment_method = models.PaymentMethod.objects.get(pk=payment_method_id)
+            with transaction.atomic():
+                order = models.Order.objects.get(pk=order_id)
+                payment_method = models.PaymentMethod.objects.get(pk=payment_method_id)
 
-            self._validate_awaiting_payment(order)
+                self._validate_awaiting_payment(order)
 
-            buyer = None
-            if order.ad_snapshot.trade_type == models.TradeType.SELL:
-                buyer = order.owner
-            else:
-                buyer = order.ad_snapshot.ad.owner
-            if request.user.wallet_hash != buyer.wallet_hash:
-                raise ValidationError("Only the buyer can upload payment proof")
+                buyer = None
+                if order.ad_snapshot.trade_type == models.TradeType.SELL:
+                    buyer = order.owner
+                else:
+                    buyer = order.ad_snapshot.ad.owner
+                if request.user.wallet_hash != buyer.wallet_hash:
+                    raise ValidationError("Only the buyer can upload payment proof")
 
-            order_payment, _ = models.OrderPayment.objects.get_or_create(
-                order=order,
-                payment_method=payment_method,
-                defaults={"payment_type": payment_method.payment_type},
-            )
+                if payment_method.owner.wallet_hash != buyer.wallet_hash:
+                    raise ValidationError("Payment method does not belong to buyer")
 
-            order.payment_methods.add(payment_method)
+                order_payment, _ = models.OrderPayment.objects.get_or_create(
+                    order=order,
+                    payment_method=payment_method,
+                    defaults={"payment_type": payment_method.payment_type},
+                )
+
+                order.payment_methods.add(payment_method)
 
             filesize = image_file.size
             if filesize > 5 * 1024 * 1024:
@@ -328,7 +332,7 @@ class OrderPaymentViewSet(viewsets.GenericViewSet):
 
     def _validate_awaiting_payment(self, order):
         """Validates that `order` is awaiting fiat payment. Raises ValidationError
-        when order's last status is not ESCRW nor PD_PN"""
+        when order's last status is not ESCROWED nor PAID_PENDING"""
 
         last_status = order.status
         if (

--- a/rampp2p/views/view_payment.py
+++ b/rampp2p/views/view_payment.py
@@ -1,4 +1,3 @@
-
 from rest_framework import status, viewsets
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -20,80 +19,95 @@ import rampp2p.utils.file_upload as file_upload_utils
 from PIL import Image
 
 import logging
+
 logger = logging.getLogger(__name__)
+
 
 class PaymentTypeView(APIView):
     authentication_classes = [IgnoreInvalidTokenAuthentication]
 
     def get(self, request):
         queryset = models.PaymentType.objects.filter(payment_currency__isnull=False)
-        currency = request.query_params.get('currency')
+        currency = request.query_params.get("currency")
         if currency:
             fiat_currency = models.FiatCurrency.objects.filter(symbol=currency)
             if not fiat_currency.exists():
-                return Response({'error': f'no such fiat currency with symbol {currency}'}, status.HTTP_400_BAD_REQUEST)
+                return Response(
+                    {"error": f"no such fiat currency with symbol {currency}"},
+                    status.HTTP_400_BAD_REQUEST,
+                )
             fiat_currency = fiat_currency.first()
             queryset = fiat_currency.payment_types
         queryset = queryset.distinct()
         serializer = serializers.PaymentTypeSerializer(queryset, many=True)
         return Response(serializer.data, status.HTTP_200_OK)
 
-class PaymentMethodViewSet(viewsets.GenericViewSet):  
+
+class PaymentMethodViewSet(viewsets.GenericViewSet):
     authentication_classes = [TokenAuthentication]
     permission_classes = [RampP2PIsAuthenticated]
     queryset = models.PaymentMethod.objects.all()
 
     def list(self, request):
-        queryset = self.get_queryset().filter(owner__wallet_hash=request.user.wallet_hash)
-        currency = request.query_params.get('currency')
+        queryset = self.get_queryset().filter(
+            owner__wallet_hash=request.user.wallet_hash
+        )
+        currency = request.query_params.get("currency")
         if currency:
             fiat_currency = models.FiatCurrency.objects.filter(symbol=currency)
             if not fiat_currency.exists():
-                return Response({'error': f'no such fiat currency with symbol {currency}'}, status.HTTP_400_BAD_REQUEST)
+                return Response(
+                    {"error": f"no such fiat currency with symbol {currency}"},
+                    status.HTTP_400_BAD_REQUEST,
+                )
             fiat_currency = fiat_currency.first()
-            currency_paymenttype_ids = fiat_currency.payment_types.values_list('id', flat=True)
+            currency_paymenttype_ids = fiat_currency.payment_types.values_list(
+                "id", flat=True
+            )
             queryset = queryset.filter(payment_type__id__in=currency_paymenttype_ids)
         serializer = serializers.PaymentMethodSerializer(queryset, many=True)
         return Response(serializer.data, status.HTTP_200_OK)
 
     def create(self, request):
         owner = request.user
-        
+
         try:
             data = request.data.copy()
-            fields = data.get('fields')
+            fields = data.get("fields")
             if fields is None or len(fields) == 0:
-                raise ValidationError('Empty payment method fields')
-            
-            payment_type = models.PaymentType.objects.get(id=data.get('payment_type'))
+                raise ValidationError("Empty payment method fields")
+
+            payment_type = models.PaymentType.objects.get(id=data.get("payment_type"))
 
             # Return error if a payment_method with same payment type already exists for this user
-            if models.PaymentMethod.objects.filter(Q(owner__wallet_hash=owner.wallet_hash) & Q(payment_type__id=payment_type.id)).exists():
-                raise ValidationError('Duplicate payment method with payment type')
+            if models.PaymentMethod.objects.filter(
+                Q(owner__wallet_hash=owner.wallet_hash)
+                & Q(payment_type__id=payment_type.id)
+            ).exists():
+                raise ValidationError("Duplicate payment method with payment type")
 
-            data = {
-                'payment_type': payment_type,
-                'owner': owner
-            }        
+            data = {"payment_type": payment_type, "owner": owner}
 
             with transaction.atomic():
                 # create payment method
                 payment_method = models.PaymentMethod.objects.create(**data)
                 # create payment method fields
                 for field in fields:
-                    field_ref = models.PaymentTypeField.objects.get(id=field['field_reference'])
+                    field_ref = models.PaymentTypeField.objects.get(
+                        id=field["field_reference"]
+                    )
                     data = {
-                        'payment_method': payment_method,
-                        'field_reference': field_ref,
-                        'value': field['value']
+                        "payment_method": payment_method,
+                        "field_reference": field_ref,
+                        "value": field["value"],
                     }
                     models.PaymentMethodField.objects.create(**data)
-                
+
             serializer = serializers.PaymentMethodSerializer(payment_method)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         except Exception as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
-    
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
     def retrieve(self, request, pk):
         try:
             payment_method = self.get_queryset().get(pk=pk)
@@ -101,68 +115,93 @@ class PaymentMethodViewSet(viewsets.GenericViewSet):
             serializer = serializers.PaymentMethodSerializer(payment_method)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except ValidationError as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
     def partial_update(self, request, pk):
         try:
             payment_method = self.get_queryset().get(pk=pk)
             self._check_permissions(request.user.wallet_hash, payment_method)
-        
-            data = request.data.copy()
-            fields = data.get('fields')
-            if fields is None or len(fields) == 0:
-                raise ValidationError('Empty payment method fields')
 
-            for field in data.get('fields'):
-                field_id = field.get('id')
+            data = request.data.copy()
+            fields = data.get("fields")
+            if fields is None or len(fields) == 0:
+                raise ValidationError("Empty payment method fields")
+
+            for field in data.get("fields"):
+                field_id = field.get("id")
                 if field_id:
-                    payment_method_field = models.PaymentMethodField.objects.get(id=field_id)
-                    payment_method_field.value = field.get('value')
+                    payment_method_field = models.PaymentMethodField.objects.get(
+                        id=field_id
+                    )
+                    payment_method_field.value = field.get("value")
                     payment_method_field.save()
-                elif field.get('value') and field.get('field_reference'):
-                    field_ref = models.PaymentTypeField.objects.get(id=field.get('field_reference'))
+                elif field.get("value") and field.get("field_reference"):
+                    field_ref = models.PaymentTypeField.objects.get(
+                        id=field.get("field_reference")
+                    )
                     data = {
-                        'payment_method': payment_method,
-                        'field_reference': field_ref,
-                        'value': field.get('value')
+                        "payment_method": payment_method,
+                        "field_reference": field_ref,
+                        "value": field.get("value"),
                     }
                     models.PaymentMethodField.objects.create(**data)
 
             serializer = serializers.PaymentMethodSerializer(payment_method)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Exception as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
-        
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
     def destroy(self, request, pk):
         try:
             payment_method = self.get_queryset().get(pk=pk)
             self._check_permissions(request.user.wallet_hash, payment_method)
-            
+
             # disable deletion if used by any Ad as payment method
-            ads_using_this = models.Ad.objects.filter(deleted_at__isnull=True, payment_methods__id=payment_method.id)
+            ads_using_this = models.Ad.objects.filter(
+                deleted_at__isnull=True, payment_methods__id=payment_method.id
+            )
             if ads_using_this.exists():
                 raise ValidationError("Unable to delete Ad payment method")
-    
+
             # disable deletion if payment method is used by ongoing orders
-            latest_status_subquery = models.Status.objects.filter(order=OuterRef('pk')).order_by('-created_at').values('status')[:1]
-            annotated_orders = models.Order.objects.annotate(latest_status = Subquery(latest_status_subquery))
-            completed_status = [models.StatusType.CANCELED, models.StatusType.RELEASED, models.StatusType.REFUNDED]
-            incomplete_orders = annotated_orders.exclude(latest_status__in=completed_status)
-            orders_using_this = incomplete_orders.filter(payment_methods__id=payment_method.id)
-            logger.warning(f'{orders_using_this.count()} orders using this payment method')
+            latest_status_subquery = (
+                models.Status.objects.filter(order=OuterRef("pk"))
+                .order_by("-created_at")
+                .values("status")[:1]
+            )
+            annotated_orders = models.Order.objects.annotate(
+                latest_status=Subquery(latest_status_subquery)
+            )
+            completed_status = [
+                models.StatusType.CANCELED,
+                models.StatusType.RELEASED,
+                models.StatusType.REFUNDED,
+            ]
+            incomplete_orders = annotated_orders.exclude(
+                latest_status__in=completed_status
+            )
+            orders_using_this = incomplete_orders.filter(
+                payment_methods__id=payment_method.id
+            )
+            logger.warning(
+                f"{orders_using_this.count()} orders using this payment method"
+            )
             if orders_using_this.exists():
-                raise ValidationError(f"Unable to delete payment method used by {orders_using_this.count()} ongoing order(s)")
-            
+                raise ValidationError(
+                    f"Unable to delete payment method used by {orders_using_this.count()} ongoing order(s)"
+                )
+
             payment_method.delete()
             return Response(status=status.HTTP_200_OK)
         except Exception as err:
-            return Response({'error': err.args[0]},status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
     def _check_permissions(self, wallet_hash, payment_method):
-        '''Throws an error if wallet_hash is not the owner of payment_method.'''        
+        """Throws an error if wallet_hash is not the owner of payment_method."""
         if wallet_hash != payment_method.owner.wallet_hash:
-            raise ValidationError('User not allowed to access this payment method.')
-        
+            raise ValidationError("User not allowed to access this payment method.")
+
+
 class OrderPaymentViewSet(viewsets.GenericViewSet):
     authentication_classes = [TokenAuthentication]
     permission_classes = [RampP2PIsAuthenticated]
@@ -172,47 +211,110 @@ class OrderPaymentViewSet(viewsets.GenericViewSet):
 
     def list(self, request):
         queryset = self.get_queryset()
-        order_id = request.query_params.get('order_id')
+        order_id = request.query_params.get("order_id")
         if order_id:
             queryset = queryset.filter(order__id=order_id)
         serializer = serializers.OrderPaymentSerializer(queryset, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
-    
+
     def retrieve(self, request, pk):
-        try: 
+        try:
             queryset = self.get_queryset().get(pk=pk)
             serializer = serializers.OrderPaymentSerializer(queryset)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except models.OrderPayment.DoesNotExist as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def upload_attachment(self, request, pk):
         try:
-            image_file = request.FILES.get('image')
-            if image_file is None: raise ValidationError('image is required')
-            order_payment_obj = models.OrderPayment.objects.prefetch_related('order').get(id=pk)
+            image_file = request.FILES.get("image")
+            if image_file is None:
+                raise ValidationError("image is required")
+            order_payment_obj = models.OrderPayment.objects.prefetch_related(
+                "order"
+            ).get(id=pk)
 
-            # Order status must be ESCROWED or PAID PENDING for payment attachment upload.
             self._validate_awaiting_payment(order_payment_obj.order)
 
             filesize = image_file.size
-            if filesize > 5 * 1024 * 1024: # 5mb limit
-                raise ValidationError(
-                    { 'image': _('File size cannot exceed 5 MB.')}
-                )
+            if filesize > 5 * 1024 * 1024:
+                raise ValidationError({"image": _("File size cannot exceed 5 MB.")})
 
             img_object = Image.open(image_file)
-            image_upload_obj = file_upload_utils.save_image(img_object, max_width=450, request=request)
+            image_upload_obj = file_upload_utils.save_image(
+                img_object, max_width=450, request=request
+            )
 
-            attachment, _ = models.OrderPaymentAttachment.objects.update_or_create(payment=order_payment_obj, image=image_upload_obj)
+            attachment, _ = models.OrderPaymentAttachment.objects.update_or_create(
+                payment=order_payment_obj, image=image_upload_obj
+            )
             serializer = serializers.OrderPaymentAttachmentSerializer(attachment)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
-        
+
         except (models.OrderPayment.DoesNotExist, ValidationError) as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
-        
-    @action(detail=True, methods=['delete'])
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=False, methods=["post"], url_path="upload-by-method")
+    def upload_attachment_by_method(self, request):
+        """
+        Upload a payment proof attachment by order_id and payment_method_id.
+        Creates the OrderPayment record if it doesn't exist yet.
+        """
+        try:
+            order_id = request.data.get("order_id")
+            payment_method_id = request.data.get("payment_method_id")
+            image_file = request.FILES.get("image")
+
+            if order_id is None or payment_method_id is None:
+                raise ValidationError("order_id and payment_method_id are required")
+            if image_file is None:
+                raise ValidationError("image is required")
+
+            order = models.Order.objects.get(pk=order_id)
+            payment_method = models.PaymentMethod.objects.get(pk=payment_method_id)
+
+            self._validate_awaiting_payment(order)
+
+            buyer = None
+            if order.ad_snapshot.trade_type == models.TradeType.SELL:
+                buyer = order.owner
+            else:
+                buyer = order.ad_snapshot.ad.owner
+            if request.user.wallet_hash != buyer.wallet_hash:
+                raise ValidationError("Only the buyer can upload payment proof")
+
+            order_payment, _ = models.OrderPayment.objects.get_or_create(
+                order=order,
+                payment_method=payment_method,
+                defaults={"payment_type": payment_method.payment_type},
+            )
+
+            order.payment_methods.add(payment_method)
+
+            filesize = image_file.size
+            if filesize > 5 * 1024 * 1024:
+                raise ValidationError({"image": _("File size cannot exceed 5 MB.")})
+
+            img_object = Image.open(image_file)
+            image_upload_obj = file_upload_utils.save_image(
+                img_object, max_width=450, request=request
+            )
+
+            attachment, _ = models.OrderPaymentAttachment.objects.update_or_create(
+                payment=order_payment, image=image_upload_obj
+            )
+            serializer = serializers.OrderPaymentAttachmentSerializer(attachment)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+        except (
+            models.Order.DoesNotExist,
+            models.PaymentMethod.DoesNotExist,
+            ValidationError,
+        ) as err:
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+
+    @action(detail=True, methods=["delete"])
     def delete_attachment(self, request, pk):
         try:
             attachment = models.OrderPaymentAttachment.objects.get(id=pk)
@@ -220,14 +322,19 @@ class OrderPaymentViewSet(viewsets.GenericViewSet):
             file_upload_utils.delete_file(attachment.image.url_path)
             attachment.delete()
             return Response(status=status.HTTP_200_OK)
-        
+
         except (models.OrderPaymentAttachment.DoesNotExist, Exception) as err:
-            return Response({'error': err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": err.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
     def _validate_awaiting_payment(self, order):
-        '''Validates that `order` is awaiting fiat payment. Raises ValidationError 
-        when order's last status is not ESCRW nor PD_PN'''
-        
+        """Validates that `order` is awaiting fiat payment. Raises ValidationError
+        when order's last status is not ESCRW nor PD_PN"""
+
         last_status = order.status
-        if last_status.status != models.StatusType.ESCROWED and last_status.status != models.StatusType.PAID_PENDING:
-            raise ValidationError({ 'order': _(f'Invalid action for {last_status.status} order')})
+        if (
+            last_status.status != models.StatusType.ESCROWED
+            and last_status.status != models.StatusType.PAID_PENDING
+        ):
+            raise ValidationError(
+                {"order": _(f"Invalid action for {last_status.status} order")}
+            )


### PR DESCRIPTION
## Summary

- Add `POST /ramp-p2p/order/payment/upload-by-method/` endpoint that allows buyers to upload payment proof by `order_id` and `payment_method_id` before formally confirming payment
- Make `OrderPayment` creation idempotent in `buyer_confirm_payment` by using `get_or_create`, so that an `OrderPayment` record created via the new early-upload endpoint is reused rather than duplicated
- Validate buyer identity and order status (`ESCROWED` / `PAID_PENDING`) on the new endpoint to prevent unauthorized or invalid uploads
- Apply code formatting (black) across `urls.py`, `view_order.py`, and `view_payment.py`

## Changes

| File | Change |
|---|---|
| `rampp2p/urls.py` | Add `order/payment/upload-by-method/` route; reformat with black |
| `rampp2p/views/view_order.py` | Reformat with black; update `buyer_confirm_payment` to use `get_or_create` for idempotent `OrderPayment` creation |
| `rampp2p/views/view_payment.py` | Add `upload_attachment_by_method` action; reformat with black |

## How it works

1. **Early upload**: Buyer calls `POST /order/payment/upload-by-method/` with `order_id`, `payment_method_id`, and `image`. If no `OrderPayment` exists for that order+method combo, one is created. The payment method is also added to the order's `payment_methods` m2m. The attachment is then saved.

2. **Confirm payment**: When the buyer later calls `buyer_confirm_payment`, `get_or_create` is used instead of `create` for `OrderPayment`, so it reuses the record created during early upload instead of creating a duplicate.