### PR TITLE
Tweak/address discovery

### DIFF
--- a/main/serializers/serializer_address_discover.py
+++ b/main/serializers/serializer_address_discover.py
@@ -3,8 +3,14 @@ from rest_framework import serializers
 
 class AddressDiscoverSetSerializer(serializers.Serializer):
     address_index = serializers.IntegerField()
-    receiving = serializers.CharField(max_length=200)
-    change = serializers.CharField(max_length=200)
+    receiving = serializers.CharField(max_length=200, required=False, allow_blank=True)
+    change = serializers.CharField(max_length=200, required=False, allow_blank=True)
+    def validate(self, data):
+        if not data.get('receiving') and not data.get('change'):
+            raise serializers.ValidationError(
+                "You must provide at least one of 'receiving' or 'change'."
+            )
+        return data
 
 
 class WalletAddressDiscoverSerializer(serializers.Serializer):
@@ -15,8 +21,8 @@ class WalletAddressDiscoverSerializer(serializers.Serializer):
 
 class AddressDiscoverResultSerializer(serializers.Serializer):
     address_index = serializers.IntegerField()
-    receiving = serializers.DictField()
-    change = serializers.DictField()
+    receiving = serializers.DictField(default=dict)
+    change = serializers.DictField(default=dict)
 
 
 class WalletAddressDiscoverResponseSerializer(serializers.Serializer):

--- a/main/views/view_address_discover.py
+++ b/main/views/view_address_discover.py
@@ -56,42 +56,45 @@ class WalletAddressDiscoverViewSet(viewsets.GenericViewSet):
         results = []
         for address_set in address_sets:
             address_index = address_set["address_index"]
-            receiving_address = address_set["receiving"]
-            change_address = address_set["change"]
+            receiving_address = address_set.get("receiving")
+            change_address = address_set.get("change")
 
             receiving_has_history = False
             change_has_history = False
 
-            try:
-                receiving_has_history = NODE.BCH.check_address_history(
-                    receiving_address
-                )
-            except Exception:
-                LOGGER.warning(
-                    "Failed to check transaction history for receiving address: %s",
-                    receiving_address,
-                )
+            result = {
+                "address_index": address_index
+            }
 
-            try:
-                change_has_history = NODE.BCH.check_address_history(change_address)
-            except Exception:
-                LOGGER.warning(
-                    "Failed to check transaction history for change address: %s",
-                    change_address,
-                )
-
-            results.append(
-                {
-                    "address_index": address_index,
-                    "receiving": {
+            if receiving_address:
+                try:
+                    receiving_has_history = NODE.BCH.check_address_history(
+                        receiving_address
+                    )
+                    result["receiving"] = {
                         "address": receiving_address,
-                        "has_history": receiving_has_history,
-                    },
-                    "change": {
+                        "has_history": receiving_has_history
+                    }
+
+                except Exception:
+                    LOGGER.warning(
+                        "Failed to check transaction history for receiving address: %s",
+                        receiving_address,
+                    )
+
+            if change_address:
+                try:
+                    change_has_history = NODE.BCH.check_address_history(change_address)
+                    result["change"] = {
                         "address": change_address,
-                        "has_history": change_has_history,
-                    },
-                }
-            )
+                        "has_history": change_has_history
+                    }
+                except Exception:
+                    LOGGER.warning(
+                        "Failed to check transaction history for change address: %s",
+                        change_address,
+                    )
+
+            results.append(result)
 
         return Response({"results": results}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Description
Minor tweak to address discovery. Allow option to independently scan receiving or change address. This is so clients have an option to stop generating address or stop requesting scan for an address type  if the gap limit of one type has been discovered. This change is non-breaking and does not affect existing response structures on the current allowed request structure.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


