### PR TITLE
Improvements/cashtoken metadata

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -941,6 +941,13 @@ class CashNonFungibleTokenAdmin(admin.ModelAdmin):
         'nft_details',
     ]
 
+    search_fields = [
+        'category',
+        'commitment',
+    ]
+
+    actions = ['refetch_metadata']
+
     def name(self, obj):
         if obj.info:
             return obj.info.name
@@ -960,6 +967,39 @@ class CashNonFungibleTokenAdmin(admin.ModelAdmin):
         if obj.info:
             return obj.info.nft_details
         return None
+
+    def refetch_metadata(self, request, queryset):
+        """Refetch token metadata from BCMR indexer for selected tokens"""
+        updated_count = 0
+        error_count = 0
+        skipped_count = 0
+
+        for token in queryset:
+            try:
+                # Force refresh metadata
+                token.fetch_metadata(force_refresh=True)
+                updated_count += 1
+            except Exception as e:
+                error_count += 1
+                import logging
+                logger = logging.getLogger(__name__)
+                logger.warning(f'Error refetching metadata for token {token.category}: {str(e)}')
+
+        if updated_count > 0:
+            self.message_user(
+                request,
+                f'Successfully refetched metadata for {updated_count} token(s).',
+                messages.SUCCESS
+            )
+
+        if error_count > 0:
+            self.message_user(
+                request,
+                f'Failed to refetch metadata for {error_count} token(s). Check logs for details.',
+                messages.WARNING
+            )
+
+    refetch_metadata.short_description = "Refetch metadata from BCMR"
     
 
 class TransactionBroadcastAdmin(DynamicRawIDMixin, admin.ModelAdmin):

--- a/main/admin.py
+++ b/main/admin.py
@@ -870,6 +870,12 @@ class CashTokenInfoAdmin(admin.ModelAdmin):
         'decimals',
     ]
 
+    search_fields = [
+        'name',
+        'symbol',
+        'description',
+    ]
+
 
 class CashFungibleTokenAdmin(admin.ModelAdmin):
     list_display = [
@@ -879,7 +885,17 @@ class CashFungibleTokenAdmin(admin.ModelAdmin):
         'decimals',
     ]
 
+    search_fields = [
+        'category',
+        'info__name',
+        'info__symbol',
+    ]
+
     actions = ['refetch_metadata']
+
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("info")
 
     def name(self, obj):
         if obj.info:
@@ -944,9 +960,14 @@ class CashNonFungibleTokenAdmin(admin.ModelAdmin):
     search_fields = [
         'category',
         'commitment',
+        'info__name',
+        'info__symbol',
     ]
 
     actions = ['refetch_metadata']
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("info")
 
     def name(self, obj):
         if obj.info:

--- a/main/admin.py
+++ b/main/admin.py
@@ -22,6 +22,7 @@ from django.utils.html import format_html
 from django.conf import settings
 import datetime
 import json
+import logging
 
 
 admin.site.site_header = 'WatchTower.Cash Admin'
@@ -916,7 +917,6 @@ class CashFungibleTokenAdmin(admin.ModelAdmin):
         """Refetch token metadata from BCMR indexer for selected tokens"""
         updated_count = 0
         error_count = 0
-        skipped_count = 0
 
         for token in queryset:
             try:
@@ -925,7 +925,6 @@ class CashFungibleTokenAdmin(admin.ModelAdmin):
                 updated_count += 1
             except Exception as e:
                 error_count += 1
-                import logging
                 logger = logging.getLogger(__name__)
                 logger.warning(f'Error refetching metadata for token {token.category}: {str(e)}')
 
@@ -993,7 +992,6 @@ class CashNonFungibleTokenAdmin(admin.ModelAdmin):
         """Refetch token metadata from BCMR indexer for selected tokens"""
         updated_count = 0
         error_count = 0
-        skipped_count = 0
 
         for token in queryset:
             try:
@@ -1002,7 +1000,6 @@ class CashNonFungibleTokenAdmin(admin.ModelAdmin):
                 updated_count += 1
             except Exception as e:
                 error_count += 1
-                import logging
                 logger = logging.getLogger(__name__)
                 logger.warning(f'Error refetching metadata for token {token.category}: {str(e)}')
 

--- a/main/admin.py
+++ b/main/admin.py
@@ -24,6 +24,7 @@ import datetime
 import json
 import logging
 
+logger = logging.getLogger(__name__)
 
 admin.site.site_header = 'WatchTower.Cash Admin'
 admin.site.site_title = 'WatchTower.Cash Admin'
@@ -925,7 +926,6 @@ class CashFungibleTokenAdmin(admin.ModelAdmin):
                 updated_count += 1
             except Exception as e:
                 error_count += 1
-                logger = logging.getLogger(__name__)
                 logger.warning(f'Error refetching metadata for token {token.category}: {str(e)}')
 
         if updated_count > 0:
@@ -1000,7 +1000,6 @@ class CashNonFungibleTokenAdmin(admin.ModelAdmin):
                 updated_count += 1
             except Exception as e:
                 error_count += 1
-                logger = logging.getLogger(__name__)
                 logger.warning(f'Error refetching metadata for token {token.category}: {str(e)}')
 
         if updated_count > 0:

--- a/main/models.py
+++ b/main/models.py
@@ -439,7 +439,7 @@ class CashNonFungibleToken(models.Model):
             'is_cashtoken': True
         }
 
-    def fetch_metadata(self, force_refresh=False, strict=True):
+    def fetch_metadata(self, force_refresh=False, strict=False):
         # If metadata already exists and we're not forcing refresh, skip fetching to avoid blocking
         if self.info and not force_refresh:
             return

--- a/main/models.py
+++ b/main/models.py
@@ -465,7 +465,7 @@ class CashNonFungibleToken(models.Model):
 
         type_metadata = data.get('type_metadata', {})
 
-        parsed = parse_bcmr_to_info(data, is_nft=True, category=self.category)
+        parsed = parse_bcmr_to_info(data, is_nft=True, category=self.category, capability=self.capability)
         if not parsed:
             return
 

--- a/main/models.py
+++ b/main/models.py
@@ -473,6 +473,85 @@ class CashNonFungibleToken(models.Model):
             'is_cashtoken': True
         }
 
+    def fetch_metadata(self, force_refresh=False, strict=True):
+        # If metadata already exists and we're not forcing refresh, skip fetching to avoid blocking
+        if self.info and not force_refresh:
+            return
+        
+        PAYTACA_BCMR_URL = f'{settings.PAYTACA_BCMR_URL}/tokens/{self.category}/{self.commitment}/'
+        try:
+            # Add timeout to prevent hanging (10 seconds for existing tokens)
+            response = requests.get(PAYTACA_BCMR_URL, timeout=10)
+            if response.status_code != 200:
+                return
+
+            data = response.json()
+            if 'error' in data.keys():
+                return data
+
+            type_metadata = data.get('type_metadata', {})
+
+            if not type_metadata and strict:
+                return dict(error=f"Missing `type_metadata` in response data", data=data)
+
+            # Truncate name and symbol if they're too long
+            name = type_metadata.get('name') or data.get('name', f'CT-{self.category[0:4]}')
+            if len(name) > 200:  # Database limit for name
+                name = name[:200]
+
+            symbol = data.get('token').get('symbol', '')
+            if symbol and len(symbol) > 100:  # Model limit for symbol
+                symbol = symbol[:100]
+
+            description = type_metadata.get('description') or data.get('description', '')
+            if description and len(description) > 1000:  # Reasonable limit for description
+                description = description[:1000]
+
+            type_metadata_uris = type_metadata.get('uris', {})
+            token_uris = data.get('uris', {})
+            image_url = type_metadata_uris.get('image', '') or token_uris.get('icon')
+            if image_url and len(image_url) > 200:  # Safe limit for URL
+                image_url = image_url[:200]
+
+            try:
+                decimals = int(data.get('token', {} ).get('decimals', None))
+            except (TypeError, ValueError):
+                decimals = None
+
+            try:
+                info, _ = CashTokenInfo.objects.get_or_create(
+                    name=name,
+                    description=description,
+                    symbol=symbol,
+                    decimals=decimals,
+                    image_url=image_url
+                )
+                self.info = info
+                self.save()
+            except CashTokenInfo.MultipleObjectsReturned:
+                pass
+
+        except (requests.Timeout, requests.RequestException) as e:
+            # Log the error but don't fail - metadata will be fetched later if needed
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.warning(f'Timeout or error fetching metadata for cashtoken {self.category}: {str(e)}')
+            # If we have existing info, keep it; otherwise create default
+            if not self.info:
+                default_details = settings.DEFAULT_TOKEN_DETAILS.get('fungible', {})
+                info, _ = CashTokenInfo.objects.get_or_create(
+                    name=default_details.get('name', f'CT-{self.category[0:4]}')[:200],
+                    symbol=default_details.get('symbol', '')[:100],
+                    defaults={
+                        'decimals': None,
+                        'description': '',
+                        'image_url': None
+                    }
+                )
+                self.info = info
+                self.save()
+
+
 class Transaction(PostgresModel):
     txid = models.CharField(max_length=70, db_index=True)
     address = models.ForeignKey(

--- a/main/models.py
+++ b/main/models.py
@@ -439,7 +439,7 @@ class CashNonFungibleToken(models.Model):
             'is_cashtoken': True
         }
 
-    def fetch_metadata(self, force_refresh=False, strict=False):
+    def fetch_metadata(self, force_refresh=False):
         # If metadata already exists and we're not forcing refresh, skip fetching to avoid blocking
         if self.info and not force_refresh:
             return
@@ -464,8 +464,6 @@ class CashNonFungibleToken(models.Model):
             return
 
         type_metadata = data.get('type_metadata', {})
-        if not type_metadata and strict:
-            return
 
         parsed = parse_bcmr_to_info(data, is_nft=True, category=self.category)
         if not parsed:

--- a/main/models.py
+++ b/main/models.py
@@ -13,6 +13,7 @@ from datetime import date
 
 from main.utils.address_validator import *
 from main.utils.address_converter import *
+from main.utils.cashtoken_meta import fetch_bcmr_raw, parse_bcmr_to_info
 import requests
 import re
 import uuid
@@ -309,59 +310,12 @@ class CashFungibleToken(models.Model):
         # If metadata already exists and we're not forcing refresh, skip fetching to avoid blocking
         if self.info and not force_refresh:
             return
-        
-        PAYTACA_BCMR_URL = f'{settings.PAYTACA_BCMR_URL}/tokens/{self.category}/'
-        try:
-            # Add timeout to prevent hanging (5 seconds for existing tokens)
-            response = requests.get(PAYTACA_BCMR_URL, timeout=5)
-            if response.status_code == 200:
-                data = response.json()
-                if 'error' not in data.keys():
-                    uris = data.get('token').get('uris')
-                    if not uris:
-                        uris = data.get('uris') or {'icon': None}
 
-                    try:
-                        decimals = int(data.get('token').get('decimals'))
-                    except (TypeError, ValueError):
-                        decimals = 0
-
-                    # Truncate name and symbol if they're too long
-                    name = data.get('name', f'CT-{self.category[0:4]}')
-                    if len(name) > 200:  # Database limit for name
-                        name = name[:200]
-
-                    symbol = data.get('token').get('symbol', '')
-                    if symbol and len(symbol) > 100:  # Model limit for symbol
-                        symbol = symbol[:100]
-
-                    description = data.get('description', '')
-                    if description and len(description) > 1000:  # Reasonable limit for description
-                        description = description[:1000]
-
-                    image_url = uris.get('icon')
-                    if image_url and len(image_url) > 200:  # Safe limit for URL
-                        image_url = image_url[:200]
-
-                    try:
-                        info, _ = CashTokenInfo.objects.get_or_create(
-                            name=name,
-                            description=description,
-                            symbol=symbol,
-                            decimals=decimals,
-                            image_url=image_url
-                        )
-                        self.info = info
-                        self.save()
-                    except CashTokenInfo.MultipleObjectsReturned:
-                        pass
-        except (requests.Timeout, requests.RequestException) as e:
-            # Log the error but don't fail - metadata will be fetched later if needed
-            import logging
-            logger = logging.getLogger(__name__)
-            logger.warning(f'Timeout or error fetching metadata for cashtoken {self.category}: {str(e)}')
-            # If we have existing info, keep it; otherwise create default
-            if not self.info:
+        data = fetch_bcmr_raw(self.category, timeout=5)
+        if 'error' in data:
+            # Only create default metadata on transport errors (timeout, connection issue).
+            # HTTP errors (404, 500) or API errors are left without default info so a retry can succeed.
+            if data.get('transport_error') and not self.info:
                 default_details = settings.DEFAULT_TOKEN_DETAILS.get('fungible', {})
                 info, _ = CashTokenInfo.objects.get_or_create(
                     name=default_details.get('name', f'CT-{self.category[0:4]}')[:200],
@@ -374,6 +328,18 @@ class CashFungibleToken(models.Model):
                 )
                 self.info = info
                 self.save()
+            return
+
+        parsed = parse_bcmr_to_info(data, is_nft=False, category=self.category)
+        if not parsed:
+            return
+
+        try:
+            info, _ = CashTokenInfo.objects.get_or_create(**parsed)
+            self.info = info
+            self.save()
+        except CashTokenInfo.MultipleObjectsReturned:
+            pass
 
 
 class CashNonFungibleTokenQuerySet(PostgresQuerySet):
@@ -477,68 +443,13 @@ class CashNonFungibleToken(models.Model):
         # If metadata already exists and we're not forcing refresh, skip fetching to avoid blocking
         if self.info and not force_refresh:
             return
-        
-        PAYTACA_BCMR_URL = f'{settings.PAYTACA_BCMR_URL}/tokens/{self.category}/{self.commitment}/'
-        try:
-            # Add timeout to prevent hanging (10 seconds for existing tokens)
-            response = requests.get(PAYTACA_BCMR_URL, timeout=10)
-            if response.status_code != 200:
-                return
 
-            data = response.json()
-            if 'error' in data.keys():
-                return data
-
-            type_metadata = data.get('type_metadata', {})
-
-            if not type_metadata and strict:
-                return dict(error=f"Missing `type_metadata` in response data", data=data)
-
-            # Truncate name and symbol if they're too long
-            name = type_metadata.get('name') or data.get('name', f'CT-{self.category[0:4]}')
-            if len(name) > 200:  # Database limit for name
-                name = name[:200]
-
-            symbol = data.get('token').get('symbol', '')
-            if symbol and len(symbol) > 100:  # Model limit for symbol
-                symbol = symbol[:100]
-
-            description = type_metadata.get('description') or data.get('description', '')
-            if description and len(description) > 1000:  # Reasonable limit for description
-                description = description[:1000]
-
-            type_metadata_uris = type_metadata.get('uris', {})
-            token_uris = data.get('uris', {})
-            image_url = type_metadata_uris.get('image', '') or token_uris.get('icon')
-            if image_url and len(image_url) > 200:  # Safe limit for URL
-                image_url = image_url[:200]
-
-            try:
-                decimals = int(data.get('token', {} ).get('decimals', None))
-            except (TypeError, ValueError):
-                decimals = None
-
-            try:
-                info, _ = CashTokenInfo.objects.get_or_create(
-                    name=name,
-                    description=description,
-                    symbol=symbol,
-                    decimals=decimals,
-                    image_url=image_url
-                )
-                self.info = info
-                self.save()
-            except CashTokenInfo.MultipleObjectsReturned:
-                pass
-
-        except (requests.Timeout, requests.RequestException) as e:
-            # Log the error but don't fail - metadata will be fetched later if needed
-            import logging
-            logger = logging.getLogger(__name__)
-            logger.warning(f'Timeout or error fetching metadata for cashtoken {self.category}: {str(e)}')
-            # If we have existing info, keep it; otherwise create default
-            if not self.info:
-                default_details = settings.DEFAULT_TOKEN_DETAILS.get('fungible', {})
+        data = fetch_bcmr_raw(self.category, commitment=self.commitment, timeout=10)
+        if 'error' in data:
+            # Only create default metadata on transport errors (timeout, connection issue).
+            # HTTP errors (404, 500) or API errors are left without default info so a retry can succeed.
+            if data.get('transport_error') and not self.info:
+                default_details = settings.DEFAULT_TOKEN_DETAILS.get('nft', {})
                 info, _ = CashTokenInfo.objects.get_or_create(
                     name=default_details.get('name', f'CT-{self.category[0:4]}')[:200],
                     symbol=default_details.get('symbol', '')[:100],
@@ -550,6 +461,22 @@ class CashNonFungibleToken(models.Model):
                 )
                 self.info = info
                 self.save()
+            return
+
+        type_metadata = data.get('type_metadata', {})
+        if not type_metadata and strict:
+            return
+
+        parsed = parse_bcmr_to_info(data, is_nft=True, category=self.category)
+        if not parsed:
+            return
+
+        try:
+            info, _ = CashTokenInfo.objects.get_or_create(**parsed)
+            self.info = info
+            self.save()
+        except CashTokenInfo.MultipleObjectsReturned:
+            pass
 
 
 class Transaction(PostgresModel):

--- a/main/serializers/serializer_cashtoken.py
+++ b/main/serializers/serializer_cashtoken.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
-import requests
 
 from django.conf import settings
+from main.utils.cashtoken_meta import fetch_bcmr_raw
 from django.db.models import Q, Sum
 from django.db.models.functions import Coalesce
 
@@ -245,41 +245,28 @@ class CashNonFungibleTokenGroupsSerializer(serializers.ModelSerializer):
         Updates with_bcmr_metadata field when metadata is successfully fetched.
         """
         category = obj.category
-        bcmr_url = f'{settings.PAYTACA_BCMR_URL}/tokens/{category}/'
-        
-        try:
-            # Fetch fresh from BCMR with timeout
-            response = requests.get(bcmr_url, timeout=5)
-            if response.status_code == 200:
-                data = response.json()
-                
-                # Check for errors in response
-                if 'error' in data:
-                    return {}
-                
-                # Metadata successfully fetched - update with_bcmr_metadata for all NFTs in this category
-                # Check if this category already has with_bcmr_metadata set to avoid redundant updates
-                has_metadata = CashNonFungibleToken.objects.filter(
-                    category=category,
-                    with_bcmr_metadata=True
-                ).exists()
-                
-                if not has_metadata:
-                    # Update all NFTs in this category to mark they have BCMR metadata
-                    CashNonFungibleToken.objects.filter(
-                        category=category
-                    ).update(with_bcmr_metadata=True)
-                    # Update the current object instance so subsequent calls use the updated value
-                    obj.with_bcmr_metadata = True
-                
-                # Return the entire BCMR response as metadata
-                return data
-            else:
-                # Non-200 status code
-                return {}
-        except Exception:
-            # Any error (timeout, network, parsing, etc.) returns empty dict
+        data = fetch_bcmr_raw(category, timeout=5)
+
+        if 'error' in data:
             return {}
+
+        # Metadata successfully fetched - update with_bcmr_metadata for all NFTs in this category
+        # Check if this category already has with_bcmr_metadata set to avoid redundant updates
+        has_metadata = CashNonFungibleToken.objects.filter(
+            category=category,
+            with_bcmr_metadata=True
+        ).exists()
+
+        if not has_metadata:
+            # Update all NFTs in this category to mark they have BCMR metadata
+            CashNonFungibleToken.objects.filter(
+                category=category
+            ).update(with_bcmr_metadata=True)
+            # Update the current object instance so subsequent calls use the updated value
+            obj.with_bcmr_metadata = True
+
+        # Return the entire BCMR response as metadata
+        return data
 
 
 class CashNonFungibleCategorySerializer(serializers.Serializer):
@@ -327,36 +314,12 @@ class CashNonFungibleTokenItemsSerializer(serializers.ModelSerializer):
         """
         category = obj.category
         commitment = obj.commitment or ''
-        
-        # Build BCMR URL: /api/tokens/<category>/<commitment>/
-        # If commitment is empty, use just /api/tokens/<category>/
-        if commitment:
-            bcmr_url = f'{settings.PAYTACA_BCMR_URL}/tokens/{category}/{commitment}/'
-        else:
-            bcmr_url = f'{settings.PAYTACA_BCMR_URL}/tokens/{category}/'
-        
-        try:
-            # Fetch fresh from BCMR with timeout
-            response = requests.get(bcmr_url, timeout=5)
-            if response.status_code == 200:
-                data = response.json()
-                
-                # Check for errors in response
-                if 'error' in data:
-                    return {}
-                
-                # Extract only type_metadata from the response
-                type_metadata = data.get('type_metadata')
-                if type_metadata:
-                    return type_metadata
-                else:
-                    return {}
-            else:
-                # Non-200 status code
-                return {}
-        except Exception:
-            # Any error (timeout, network, parsing, etc.) returns empty dict
+
+        data = fetch_bcmr_raw(category, commitment=commitment or None, timeout=5)
+        if 'error' in data:
             return {}
+
+        return data.get('type_metadata', {})
 
 
 class CashNonFungibleTokenSerializer(serializers.ModelSerializer):

--- a/main/tasks.py
+++ b/main/tasks.py
@@ -266,92 +266,9 @@ def get_cashtoken_meta_data(
 ):
     LOGGER.info(f'Fetching cashtoken metadata for {category} from BCMR')
 
-    METADATA = None
-    detail_key = 'nft' if is_nft else 'fungible'
-    default_details = settings.DEFAULT_TOKEN_DETAILS[detail_key]
-
-    # TODO: Don't fetch from BCMR indexer for now, to be reconsidered later
-    # PAYTACA_BCMR_URL = f'{settings.PAYTACA_BCMR_URL}/tokens/{category}/'
-    # response = requests.get(PAYTACA_BCMR_URL)
-
-    # if response.status_code == 200:
-    #     METADATA = response.json()
-    #     if "error" in METADATA:
-    #         METADATA = None
-
-    if METADATA:
-        # Truncate all string fields to safe lengths
-        name = (METADATA['name'] or default_details['name'])[:200]  # Safe limit for name
-        description = METADATA['description'][:1000] if METADATA['description'] else ''  # Reasonable limit for description
-        symbol = (METADATA['symbol'] or default_details['symbol'])[:100]  # Model limit for symbol
-        decimals = METADATA['decimals']
-        image_url = METADATA['uris']['icon'][:200] if METADATA['uris'].get('icon') else None  # Safe limit for URL
-        
-        # nft_details field for FT are {}
-        # nft_details field for NFTs are:
-        #   if minting: nft_details = children types or {}
-        #   else: nft_details = child type details (to include extensions and other data) or {}
-        nfts = None
-
-        if is_nft:
-            _capability = capability.lower()
-            types = METADATA['types']
-
-            if _capability == 'minting':
-                nfts = types
-            else:
-                if types:
-                    if commitment in types.keys():
-                        nfts = types[commitment]
-                        nft_keys = nfts.keys()
-
-                        if 'name' in nft_keys:
-                            name = nfts['name'][:200]  # Safe limit for name
-                        if 'description' in nft_keys:
-                            description = nfts['description'][:1000] if nfts['description'] else ''  # Reasonable limit for description
-                        if 'uris' in nft_keys:
-                            uris = nfts['uris']
-                            if 'icon' in uris.keys():
-                                image_url = uris['icon'][:200] if uris['icon'] else None  # Safe limit for URL
-        data = {
-            'name': name,
-            'description': description,
-            'symbol': symbol,
-            'decimals': decimals,
-            'image_url': image_url
-        }
-
-        if nfts:
-            data['nft_details'] = nfts
-        
-        # did not use get_or_create bec of async multiple objects returned error
-        cashtoken_infos = CashTokenInfo.objects.filter(**data)
-        if cashtoken_infos.exists():
-            cashtoken_info = cashtoken_infos.first()
-        else:
-            cashtoken_info = CashTokenInfo(**data)
-            cashtoken_info.save()
-    else:
-        # save as default metadata/info if there is no record of metadata from BCMR
-        name = default_details['name'][:200]  # Safe limit for name
-        symbol = default_details['symbol'][:100]  # Model limit for symbol
-            
-        # did not use get_or_create bec of async multiple objects returned error
-        cashtoken_infos = CashTokenInfo.objects.filter(name=name, symbol=symbol)
-        if cashtoken_infos.exists():
-            cashtoken_info = cashtoken_infos.first()
-        else:
-            cashtoken_info = CashTokenInfo(name=name, symbol=symbol)
-            cashtoken_info.save()
+    cashtoken = None
 
     if is_nft:
-        if from_bcmr_webhook:
-            nfts = CashNonFungibleToken.objects.filter(
-                category=category,
-                commitment=commitment
-            )
-            nfts.update(info=cashtoken_info)
-
         cashtoken, _ = CashNonFungibleToken.objects.get_or_create(
             current_index=index,
             current_txid=txid
@@ -359,10 +276,13 @@ def get_cashtoken_meta_data(
         cashtoken.category = category
         cashtoken.commitment = commitment
         cashtoken.capability = capability
-        cashtoken.info = cashtoken_info
         cashtoken.save()
-        cashtoken.fetch_metadata(force_refresh=True, strict=True)
         resolve_ct_nft_genesis(cashtoken, txid=txid)
+        cashtoken.fetch_metadata(force_refresh=True, strict=True)
+
+        if from_bcmr_webhook:
+            # Propagate the fetched (or default) info to all matching NFTs
+            CashNonFungibleToken.objects.filter(category=category, commitment=commitment).update(info=cashtoken.info)
 
     if not is_nft or nft_has_fungible:
         _cashtoken, _ = CashFungibleToken.objects.get_or_create(category=category)
@@ -371,12 +291,11 @@ def get_cashtoken_meta_data(
             try:
                 _cashtoken.fetch_metadata()
             except Exception as e:
-                import logging
-                logger = logging.getLogger(__name__)
-                logger.warning(f'Error fetching cashtoken metadata for {category}: {str(e)}')
+                LOGGER.warning(f'Error fetching cashtoken metadata for {category}: {str(e)}')
                 # Continue even if metadata fetch failed
 
-        if not is_nft: cashtoken = _cashtoken
+        if not is_nft:
+            cashtoken = _cashtoken
 
     return cashtoken
 

--- a/main/tasks.py
+++ b/main/tasks.py
@@ -361,6 +361,7 @@ def get_cashtoken_meta_data(
         cashtoken.capability = capability
         cashtoken.info = cashtoken_info
         cashtoken.save()
+        cashtoken.fetch_metadata(force_refresh=True, strict=True)
         resolve_ct_nft_genesis(cashtoken, txid=txid)
 
     if not is_nft or nft_has_fungible:
@@ -1761,6 +1762,7 @@ def parse_contract_history(txid, address, tx_fee=None, senders=[], recipients=[]
                                 current_txid=txid,
                                 current_index=ct_index
                             )
+                            cashtoken_nft.fetch_metadata(force_refresh=True)
 
         txn = txns.last()
         spent_txn = spent_txns.last()
@@ -2056,6 +2058,7 @@ def parse_wallet_history(self, txid, wallet_handle, tx_fee=None, senders=[], rec
                                         current_txid=txid,
                                         current_index=ct_index
                                     )
+                                    cashtoken_nft.fetch_metadata(force_refresh=True)
 
             elif wallet.wallet_type == 'slp':
                 if key != BCH_OR_SLP:

--- a/main/tasks.py
+++ b/main/tasks.py
@@ -278,7 +278,7 @@ def get_cashtoken_meta_data(
         cashtoken.capability = capability
         cashtoken.save()
         resolve_ct_nft_genesis(cashtoken, txid=txid)
-        cashtoken.fetch_metadata(force_refresh=from_bcmr_webhook, strict=from_bcmr_webhook)
+        cashtoken.fetch_metadata(force_refresh=from_bcmr_webhook)
 
         if from_bcmr_webhook:
             # Propagate the fetched (or default) info to all matching NFTs

--- a/main/tasks.py
+++ b/main/tasks.py
@@ -278,7 +278,7 @@ def get_cashtoken_meta_data(
         cashtoken.capability = capability
         cashtoken.save()
         resolve_ct_nft_genesis(cashtoken, txid=txid)
-        cashtoken.fetch_metadata(force_refresh=True, strict=True)
+        cashtoken.fetch_metadata(force_refresh=from_bcmr_webhook, strict=from_bcmr_webhook)
 
         if from_bcmr_webhook:
             # Propagate the fetched (or default) info to all matching NFTs

--- a/main/tasks.py
+++ b/main/tasks.py
@@ -1681,7 +1681,7 @@ def parse_contract_history(txid, address, tx_fee=None, senders=[], recipients=[]
                                 current_txid=txid,
                                 current_index=ct_index
                             )
-                            cashtoken_nft.fetch_metadata(force_refresh=True)
+                            cashtoken_nft.fetch_metadata()
 
         txn = txns.last()
         spent_txn = spent_txns.last()
@@ -1977,7 +1977,7 @@ def parse_wallet_history(self, txid, wallet_handle, tx_fee=None, senders=[], rec
                                         current_txid=txid,
                                         current_index=ct_index
                                     )
-                                    cashtoken_nft.fetch_metadata(force_refresh=True)
+                                    cashtoken_nft.fetch_metadata()
 
             elif wallet.wallet_type == 'slp':
                 if key != BCH_OR_SLP:

--- a/main/utils/cashtoken_meta.py
+++ b/main/utils/cashtoken_meta.py
@@ -107,5 +107,7 @@ def parse_bcmr_to_info(data, is_nft=False, category=None, capability=None):
     # unable to find tokens that cover this case
     if isinstance(capability, str) and capability.lower() == "minting" and data.get('types'):
         result['nft_details'] = data.get('types')
+    elif type_metadata:
+        result['nft_details'] = type_metadata
 
     return result

--- a/main/utils/cashtoken_meta.py
+++ b/main/utils/cashtoken_meta.py
@@ -76,7 +76,7 @@ def parse_bcmr_to_info(data, is_nft=False, category=None, capability=None):
         description = type_metadata.get('description') or data.get('description', '')
         type_metadata_uris = type_metadata.get('uris', {})
         token_uris = data.get('uris', {})
-        image_url = type_metadata_uris.get('image') or type_metadata.get('icon') or token_uris.get('icon')
+        image_url = type_metadata_uris.get('image') or type_metadata_uris.get('icon') or token_uris.get('icon')
         try:
             decimals = int(data.get('token', {}).get('decimals'))
         except (TypeError, ValueError):

--- a/main/utils/cashtoken_meta.py
+++ b/main/utils/cashtoken_meta.py
@@ -54,11 +54,13 @@ def parse_bcmr_to_info(data, is_nft=False, category=None, capability=None):
         Whether to extract NFT-specific fields (type_metadata priority) or FT fields.
     category : str, optional
         Used to build a fallback name like "CT-xxxx".
+    capability: str, optional
+        Used as condition for `nft_details` population
 
     Returns
     -------
     dict or None
-        A dict with keys: name, description, symbol, decimals, image_url.
+        A dict with keys: name, description, symbol, decimals, image_url, and an optional nft_details.
         Returns None if the input data is missing or contains an error.
     """
     if not data or 'error' in data:

--- a/main/utils/cashtoken_meta.py
+++ b/main/utils/cashtoken_meta.py
@@ -60,7 +60,8 @@ def parse_bcmr_to_info(data, is_nft=False, category=None, capability=None):
     Returns
     -------
     dict or None
-        A dict with keys: name, description, symbol, decimals, image_url, and an optional nft_details.
+        A dict with keys: name, description, symbol, decimals, image_url.
+        nft_details is also included for minting nft types
         Returns None if the input data is missing or contains an error.
     """
     if not data or 'error' in data:
@@ -104,7 +105,7 @@ def parse_bcmr_to_info(data, is_nft=False, category=None, capability=None):
 
     # Kept existing logic for populating nft_details from previous implementation of `get_cashtoken_meta_data` however
     # unable to find tokens that cover this case
-    if isinstance(capability, str) and capability.lower() === "minting" and data.get('types'):
+    if isinstance(capability, str) and capability.lower() == "minting" and data.get('types'):
         result['nft_details'] = data.get('types')
 
     return result

--- a/main/utils/cashtoken_meta.py
+++ b/main/utils/cashtoken_meta.py
@@ -73,11 +73,12 @@ def parse_bcmr_to_info(data, is_nft=False, category=None):
         description = type_metadata.get('description') or data.get('description', '')
         type_metadata_uris = type_metadata.get('uris', {})
         token_uris = data.get('uris', {})
-        image_url = type_metadata_uris.get('image') or token_uris.get('icon')
+        image_url = type_metadata_uris.get('image') or type_metadata.get('icon') or token_uris.get('icon')
         try:
             decimals = int(data.get('token', {}).get('decimals'))
         except (TypeError, ValueError):
             decimals = None
+
     else:
         name = data.get('name') or fallback_name
         symbol = data.get('token', {}).get('symbol', '')
@@ -91,10 +92,15 @@ def parse_bcmr_to_info(data, is_nft=False, category=None):
         except (TypeError, ValueError):
             decimals = 0
 
-    return {
+    result = {
         'name': _truncate(name, 200),
         'description': _truncate(description, 1000),
         'symbol': _truncate(symbol, 100),
         'decimals': decimals,
         'image_url': _truncate(image_url, 200),
     }
+
+    if data.get('types'):
+        result['nft_details'] = data.get('types')
+
+    return result

--- a/main/utils/cashtoken_meta.py
+++ b/main/utils/cashtoken_meta.py
@@ -42,7 +42,7 @@ def _truncate(value, max_length):
     return value
 
 
-def parse_bcmr_to_info(data, is_nft=False, category=None):
+def parse_bcmr_to_info(data, is_nft=False, category=None, capability=None):
     """
     Extract and normalize token metadata from a BCMR JSON response for storage in CashTokenInfo.
 
@@ -100,7 +100,9 @@ def parse_bcmr_to_info(data, is_nft=False, category=None):
         'image_url': _truncate(image_url, 200),
     }
 
-    if data.get('types'):
+    # Kept existing logic for populating nft_details from previous implementation of `get_cashtoken_meta_data` however
+    # unable to find tokens that cover this case
+    if isinstance(capability, str) and capability.lower() === "minting" and data.get('types'):
         result['nft_details'] = data.get('types')
 
     return result

--- a/main/utils/cashtoken_meta.py
+++ b/main/utils/cashtoken_meta.py
@@ -1,0 +1,100 @@
+import logging
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_bcmr_raw(category, commitment=None, timeout=None):
+    """
+    Fetch raw metadata from the BCMR indexer for a cashtoken category (and optional commitment).
+    Returns the parsed JSON dict on success.
+    Returns a dict with an 'error' key on failure (timeout, HTTP error, invalid JSON, or API error).
+    """
+    url = f'{settings.PAYTACA_BCMR_URL}/tokens/{category}/'
+    if commitment:
+        url = f'{url}{commitment}/'
+
+    try:
+        response = requests.get(url, timeout=timeout)
+    except (requests.Timeout, requests.RequestException) as e:
+        logger.warning(f'Timeout or error fetching metadata for cashtoken {category}: {str(e)}')
+        return dict(error=str(e), timeout=True, transport_error=True)
+
+    if response.status_code != 200:
+        return dict(error=f'HTTP {response.status_code}', status_code=response.status_code, http_error=True)
+
+    try:
+        data = response.json()
+    except ValueError:
+        return dict(error='Invalid JSON response', parse_error=True)
+
+    if 'error' in data:
+        return dict(error=data['error'], api_error=True)
+
+    return data
+
+
+def _truncate(value, max_length):
+    """Truncate a string value to a safe length."""
+    if value and len(value) > max_length:
+        return value[:max_length]
+    return value
+
+
+def parse_bcmr_to_info(data, is_nft=False, category=None):
+    """
+    Extract and normalize token metadata from a BCMR JSON response for storage in CashTokenInfo.
+
+    Parameters
+    ----------
+    data : dict
+        The raw BCMR JSON response.
+    is_nft : bool
+        Whether to extract NFT-specific fields (type_metadata priority) or FT fields.
+    category : str, optional
+        Used to build a fallback name like "CT-xxxx".
+
+    Returns
+    -------
+    dict or None
+        A dict with keys: name, description, symbol, decimals, image_url.
+        Returns None if the input data is missing or contains an error.
+    """
+    if not data or 'error' in data:
+        return None
+
+    fallback_name = f'CT-{category[:4]}' if category else 'CashToken'
+
+    if is_nft:
+        type_metadata = data.get('type_metadata', {})
+        name = type_metadata.get('name') or data.get('name') or fallback_name
+        symbol = data.get('token', {}).get('symbol', '')
+        description = type_metadata.get('description') or data.get('description', '')
+        type_metadata_uris = type_metadata.get('uris', {})
+        token_uris = data.get('uris', {})
+        image_url = type_metadata_uris.get('image') or token_uris.get('icon')
+        try:
+            decimals = int(data.get('token', {}).get('decimals'))
+        except (TypeError, ValueError):
+            decimals = None
+    else:
+        name = data.get('name') or fallback_name
+        symbol = data.get('token', {}).get('symbol', '')
+        description = data.get('description', '')
+        uris = data.get('token', {}).get('uris')
+        if not uris:
+            uris = data.get('uris') or {'icon': None}
+        image_url = uris.get('icon')
+        try:
+            decimals = int(data.get('token', {}).get('decimals'))
+        except (TypeError, ValueError):
+            decimals = 0
+
+    return {
+        'name': _truncate(name, 200),
+        'description': _truncate(description, 1000),
+        'symbol': _truncate(symbol, 100),
+        'decimals': decimals,
+        'image_url': _truncate(image_url, 200),
+    }


### PR DESCRIPTION
## Description
- Added in flow for fetching and saving Cashtoken NFTs metadata
- Unify logic for fetching cashtoken metadata into functions:
  - Added function for fetching raw BCMR data
  - Added single function for parsing BCMR data into `CashTokenInfo` ready data.
- Updated `CashFungibleToken.fetch_metadata`, `CashNonFungibleToken.fetch_metadata`, `get_cashtoken_meta_data`, & serializers cashtoken to use new function.

Fixes # (issue)


## Screenshots (if applicable):
(Include screenshots for UI-related changes)


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Tested manually through api docs using `stablehedge/test-utils/process_tx/` with transactions with fungible and non fungible tokens

## @mentions
Mention the person or team responsible for reviewing the proposed changes.
