### PR TITLE
paytacapos: rename NFC serializers and view actions for naming consistency

### DIFF
--- a/paytacapos/serializers.py
+++ b/paytacapos/serializers.py
@@ -183,11 +183,10 @@ class BaseLinkRequestSerializer(PermissionSerializerMixin, serializers.Serialize
 class PosDeviceLinkRequestSerializer(BaseLinkRequestSerializer):
     encrypted_xpubkey = serializers.CharField()
 
-
 class PosDeviceLinkRequestV2Serializer(BaseLinkRequestSerializer):
     encrypted_data = serializers.CharField()
 
-class PosDeviceSetupNfcPaymentSerializer(PermissionSerializerMixin, serializers.Serializer):
+class PosDeviceNfcRequestSerializer(PermissionSerializerMixin, serializers.Serializer):
     HARD_MIN_TTL = 60 * 5
     HARD_MAX_TTL = 86_400 * 7
 
@@ -263,7 +262,7 @@ class PosDeviceSetupNfcPaymentSerializer(PermissionSerializerMixin, serializers.
         return { "code": code, "expires": expires.timestamp() }
 
 
-class RedeemNfcSetupCodeSerializer(serializers.Serializer):
+class RedeemNfcRequestCodeSerializer(serializers.Serializer):
     verifying_pubkey = serializers.CharField(write_only=True)
     nfc_code = serializers.CharField()
 
@@ -271,8 +270,8 @@ class RedeemNfcSetupCodeSerializer(serializers.Serializer):
         nfc_code = data["nfc_code"]
         verifying_pubkey = data["verifying_pubkey"]
 
-        nfc_request_data = PosDeviceSetupNfcPaymentSerializer.retrieve_setup_request_data(nfc_code)
-        data_serializer = PosDeviceSetupNfcPaymentSerializer(data=nfc_request_data)
+        nfc_request_data = PosDeviceNfcRequestSerializer.retrieve_setup_request_data(nfc_code)
+        data_serializer = PosDeviceNfcRequestSerializer(data=nfc_request_data)
         if not data_serializer.is_valid():
             raise serializers.ValidationError("data from nfc setup code is invalid")
 
@@ -297,7 +296,7 @@ class RedeemNfcSetupCodeSerializer(serializers.Serializer):
         pos_device.save()
 
         nfc_code = self.validated_data["nfc_code"]
-        REDIS_CLIENT.delete(PosDeviceSetupNfcPaymentSerializer.generate_redis_key(nfc_code))
+        REDIS_CLIENT.delete(PosDeviceNfcRequestSerializer.generate_redis_key(nfc_code))
 
         return pos_device
 

--- a/paytacapos/serializers.py
+++ b/paytacapos/serializers.py
@@ -236,7 +236,7 @@ class PosDeviceNfcRequestSerializer(PermissionSerializerMixin, serializers.Seria
         return f"posdevicenfcsetup:{code}"
     
     @classmethod
-    def retrieve_setup_request_data(cls, code):
+    def retrieve_request_code_data(cls, code):
         redis_key = cls.generate_redis_key(code)
         encoded_data = REDIS_CLIENT.get(redis_key)
         try:
@@ -244,7 +244,7 @@ class PosDeviceNfcRequestSerializer(PermissionSerializerMixin, serializers.Seria
         except (json.JSONDecodeError, TypeError):
             return None
     
-    def save_setup_request(self):
+    def save_request_code(self):
         code = uuid4().hex
         redis_key = self.generate_redis_key(code)
         data = json.dumps(self.validated_data).encode()
@@ -270,10 +270,10 @@ class RedeemNfcRequestCodeSerializer(serializers.Serializer):
         nfc_code = data["nfc_code"]
         verifying_pubkey = data["verifying_pubkey"]
 
-        nfc_request_data = PosDeviceNfcRequestSerializer.retrieve_setup_request_data(nfc_code)
+        nfc_request_data = PosDeviceNfcRequestSerializer.retrieve_request_code_data(nfc_code)
         data_serializer = PosDeviceNfcRequestSerializer(data=nfc_request_data)
         if not data_serializer.is_valid():
-            raise serializers.ValidationError("data from nfc setup code is invalid")
+            raise serializers.ValidationError("data from nfc request code is invalid")
 
         encrypted_data = data_serializer.validated_data["encrypted_data"]
         signature = data_serializer.validated_data["signature"]

--- a/paytacapos/views.py
+++ b/paytacapos/views.py
@@ -169,7 +169,7 @@ class PosDeviceViewSet(
     def generate_nfc_request_code(self, request, *args, **kwargs):
         serializer = PosDeviceNfcRequestSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
-        data = serializer.save_setup_request()
+        data = serializer.save_request_code()
         return Response(data)
 
     @swagger_auto_schema(
@@ -214,7 +214,7 @@ class PosDeviceViewSet(
     @decorators.action(methods=["get"], detail=False)
     def nfc_request_code_data(self, request, *args, **kwargs):
         nfc_code = request.query_params.get("code", None)
-        nfc_request_data = PosDeviceNfcRequestSerializer.retrieve_setup_request_data(nfc_code)
+        nfc_request_data = PosDeviceNfcRequestSerializer.retrieve_request_code_data(nfc_code)
         serializer = PosDeviceNfcRequestSerializer(data=nfc_request_data, context={'request': request})
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/paytacapos/views.py
+++ b/paytacapos/views.py
@@ -164,10 +164,10 @@ class PosDeviceViewSet(
         data = serializer.save_link_request()
         return Response(data)
     
-    @swagger_auto_schema(method="post", request_body=PosDeviceSetupNfcPaymentSerializer, responses={ 200: PosDeviceLinkSerializer })
+    @swagger_auto_schema(method="post", request_body=PosDeviceNfcRequestSerializer, responses={ 200: PosDeviceLinkSerializer })
     @decorators.action(methods=["post"], detail=False)
-    def generate_nfc_setup_code(self, request, *args, **kwargs):
-        serializer = PosDeviceSetupNfcPaymentSerializer(data=request.data, context={'request': request})
+    def generate_nfc_request_code(self, request, *args, **kwargs):
+        serializer = PosDeviceNfcRequestSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
         data = serializer.save_setup_request()
         return Response(data)
@@ -212,10 +212,10 @@ class PosDeviceViewSet(
         ]
     )
     @decorators.action(methods=["get"], detail=False)
-    def nfc_code_data(self, request, *args, **kwargs):
+    def nfc_request_code_data(self, request, *args, **kwargs):
         nfc_code = request.query_params.get("code", None)
-        nfc_request_data = PosDeviceSetupNfcPaymentSerializer.retrieve_setup_request_data(nfc_code)
-        serializer = PosDeviceSetupNfcPaymentSerializer(data=nfc_request_data, context={'request': request})
+        nfc_request_data = PosDeviceNfcRequestSerializer.retrieve_setup_request_data(nfc_code)
+        serializer = PosDeviceNfcRequestSerializer(data=nfc_request_data, context={'request': request})
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
         return Response(serializer.validated_data["encrypted_data"])
@@ -246,10 +246,10 @@ class PosDeviceViewSet(
         send_device_update(pos_device, action="link")
         return Response(self.serializer_class(pos_device).data)
     
-    @swagger_auto_schema(method="post", request_body=RedeemNfcSetupCodeSerializer)
+    @swagger_auto_schema(method="post", request_body=RedeemNfcRequestCodeSerializer)
     @decorators.action(methods=["post"], detail=False)
     def redeem_nfc_request_code(self, request):
-        serializer = RedeemNfcSetupCodeSerializer(data=request.data)
+        serializer = RedeemNfcRequestCodeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         instance = serializer.save()
         return Response(self.serializer_class(instance).data)


### PR DESCRIPTION
## Description
Renames NFC-related serializers and view actions in `paytacapos` to use consistent `nfc_request` terminology across the codebase, replacing the mixed `nfc_setup` / `nfc_payment` naming.


## Screenshots (if applicable):
(Include screenshots for UI-related changes)


## Type of Change
- [x] Refactor

Note: This is a internal rename/refactor. If any external clients reference the old view action URLs (`generate_nfc_setup_code`, `nfc_code_data`), those will need to be updated.


## Test Notes
No logic changes — only renames. Verify existing NFC request/redeem flows still work end-to-end via the updated endpoints:

- `POST generate_nfc_request_code`
- `GET nfc_request_code_data`
- `POST redeem_nfc_request_code`

No new dependencies.

## @mentions
@joemarct 
