### PR TITLE
Remove HasMinPaytacaVersionHeader from paytacapos permission chains

### DIFF
--- a/paytacapos/serializers.py
+++ b/paytacapos/serializers.py
@@ -16,7 +16,6 @@ from anyhedge.utils.address import pubkey_to_cashaddr
 from rampp2p.models import MarketPrice
 
 from .models import *
-from .permissions import HasMinPaytacaVersionHeader
 from .utils.broadcast import broadcast_transaction
 from .utils.totp import generate_pos_device_totp
 from .utils.websocket import send_device_update
@@ -133,10 +132,6 @@ class BaseLinkRequestSerializer(PermissionSerializerMixin, serializers.Serialize
 
         request = self.context["request"]
 
-        # older versions didnt need authentication
-        if HasMinPaytacaVersionHeader.on_request(request):
-            return
-
         wallet = request.user
 
         if not isinstance(wallet, Wallet) or not wallet.is_authenticated:
@@ -214,10 +209,6 @@ class PosDeviceNfcRequestSerializer(PermissionSerializerMixin, serializers.Seria
             return
 
         request = self.context["request"]
-
-        # older versions didnt need authentication
-        if HasMinPaytacaVersionHeader.on_request(request):
-            return
 
         wallet = request.user
 
@@ -561,10 +552,6 @@ class PosDeviceSerializer(PermissionSerializerMixin, serializers.ModelSerializer
 
         request = self.context["request"]
 
-        # older versions didnt need authentication
-        if HasMinPaytacaVersionHeader.on_request(request):
-            return
-
         wallet = request.user
 
         if not isinstance(wallet, Wallet) or not wallet.is_authenticated:
@@ -816,10 +803,6 @@ class MerchantSerializer(PermissionSerializerMixin, serializers.ModelSerializer)
         
         request = self.context["request"]
 
-        # older versions didnt need authentication
-        if HasMinPaytacaVersionHeader.on_request(request):
-            return
-
         wallet = request.user
 
         if not isinstance(wallet, Wallet) or not wallet.is_authenticated:
@@ -924,10 +907,6 @@ class BranchSerializer(PermissionSerializerMixin, serializers.ModelSerializer):
             return
         
         request = self.context["request"]
-
-        # older versions didnt need authentication
-        if HasMinPaytacaVersionHeader.on_request(request):
-            return
 
         wallet = request.user
 

--- a/paytacapos/views.py
+++ b/paytacapos/views.py
@@ -27,7 +27,7 @@ from rest_framework.exceptions import MethodNotAllowed
 
 from .serializers import *
 from .filters import *
-from .permissions import HasMerchantObjectPermission, HasMinPaytacaVersionHeader, HasPaymentObjectPermission
+from .permissions import HasMerchantObjectPermission, HasPaymentObjectPermission
 from .pagination import CustomLimitOffsetPagination, WalletHistoryPageNumberPagination
 from .utils.websocket import send_device_update
 from .utils.report import SalesSummary
@@ -76,7 +76,7 @@ class PosDeviceViewSet(
     filterset_class = PosDeviceFilter
 
     permission_classes = [
-        HasMinPaytacaVersionHeader | HasMerchantObjectPermission,
+        HasMerchantObjectPermission,
     ]
 
     authentication_classes = [
@@ -314,7 +314,7 @@ class MerchantViewSet(viewsets.ModelViewSet):
     filterset_class = MerchantFilter
 
     permission_classes = [
-        HasMinPaytacaVersionHeader | HasMerchantObjectPermission,
+        HasMerchantObjectPermission,
     ]
     authentication_classes = [
         WalletAuthentication,
@@ -507,7 +507,7 @@ class BranchViewSet(viewsets.ModelViewSet):
     filterset_class = BranchFilter
 
     permission_classes = [
-        HasMinPaytacaVersionHeader | HasMerchantObjectPermission,
+        HasMerchantObjectPermission,
     ]
 
     authentication_classes = [


### PR DESCRIPTION
## Description

Removes `HasMinPaytacaVersionHeader` from the permission chains in `PosDeviceViewSet`, `MerchantViewSet`, and `BranchViewSet`, and removes the corresponding `on_request()` bypass blocks in serializer `check_permissions` methods.

This permission was originally intended to grandfather old app versions (≤0.19.1) that did not send the `X_PAYTACA_APP_VERSION` header. However, its design made it indistinguishable from a request that simply omits the header, causing it to unintentionally bypass the paired permission check on write operations. Given that app version 0.19.1 is no longer in active use, the permission is no longer necessary.

## Screenshots (if applicable):
N/A

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test Notes

**Manual testing:**
1. Send a PATCH/POST/DELETE request to `/api/paytacapos/merchants/`, `/devices/`, or `/branches/` **without** any auth headers — should return `403`
2. Send the same requests **with** a valid wallet auth header — should succeed as before
3. Send GET requests without auth — should still return `200`

No new dependencies. No migrations required.

The change affects `PosDeviceViewSet`, `MerchantViewSet`, and `BranchViewSet`. Read operations and authenticated write operations are unaffected. Users on app version ≤0.19.1 performing write operations will receive a `403` until they update.

## @mentions
@joemarct @khirvy019 