### PR TITLE
feat: periodic multi-currency BCH price fetch with dynamic currency detection

### DIFF
--- a/main/tasks.py
+++ b/main/tasks.py
@@ -2645,11 +2645,14 @@ def resolve_wallet_history_usd_values(txid=None, is_contract=False):
 def _get_active_wallet_currencies(max_currencies=16, cache_ttl=3600):
     """Return currencies used by recently-active wallets, cached in Redis for 1 hour."""
     cache_key = "active_wallet_currencies"
-    cached = REDIS_STORAGE.get(cache_key)
-    if cached:
-        currencies = json.loads(cached.decode())
-        if isinstance(currencies, list) and currencies:
-            return currencies
+    try:
+        cached = REDIS_STORAGE.get(cache_key)
+        if cached:
+            currencies = json.loads(cached.decode())
+            if isinstance(currencies, list) and currencies:
+                return currencies
+    except Exception:
+        pass
 
     recent = timezone.now() - timezone.timedelta(days=30)
     active_wallets = WalletHistory.objects.filter(
@@ -2668,7 +2671,10 @@ def _get_active_wallet_currencies(max_currencies=16, cache_ttl=3600):
     if "USD" not in currencies:
         currencies.insert(0, "USD")
 
-    REDIS_STORAGE.set(cache_key, json.dumps(currencies), ex=cache_ttl)
+    try:
+        REDIS_STORAGE.set(cache_key, json.dumps(currencies), ex=cache_ttl)
+    except Exception:
+        pass
     return currencies
 
 
@@ -2690,25 +2696,33 @@ def fetch_latest_bch_fiat_prices(currencies=None):
         timeout=15,
         headers={"x-cg-pro-api-key": settings.COINGECKO_API_KEY},
     )
-    response_timestamp = timezone.datetime.strptime(
-        resp.headers["Date"], "%a, %d %b %Y %H:%M:%S %Z"
-    ).replace(tzinfo=pytz.UTC)
+    response_timestamp = timezone.now()
+    date_header = resp.headers.get("Date")
+    if date_header:
+        response_timestamp = timezone.datetime.strptime(
+            date_header, "%a, %d %b %Y %H:%M:%S %Z"
+        ).replace(tzinfo=pytz.UTC)
     rates = resp.json().get("bitcoin-cash", {})
 
     results = []
     for currency in currencies:
         currency_low = currency.lower()
         if currency_low == "ars":
-            usd_rate = Decimal(rates.get("usd", 0))
-            yadio = requests.get(f"https://api.yadio.io/rate/{currency_low}/usd", timeout=15).json()
+            usd_rate = Decimal(str(rates.get("usd", 0)))
+            try:
+                yadio = requests.get(f"https://api.yadio.io/rate/{currency_low}/usd", timeout=15).json()
+            except (requests.RequestException, ValueError) as e:
+                LOGGER.warning(f"Yadio fetch failed for ARS: {e}")
+                continue
             if isinstance(yadio, dict) and "rate" in yadio:
-                price_value = Decimal(yadio["rate"]) * usd_rate
-                ts = timezone.datetime.fromtimestamp(yadio.get("timestamp", 0) / 1000, tz=pytz.UTC)
+                price_value = Decimal(str(yadio["rate"])) * usd_rate
+                yadio_ts = yadio.get("timestamp") or response_timestamp.timestamp()
+                ts = timezone.datetime.fromtimestamp(yadio_ts / 1000, tz=pytz.UTC)
                 source = "coingecko-yadio"
             else:
                 continue
         elif currency_low in rates:
-            price_value = Decimal(rates[currency_low])
+            price_value = Decimal(str(rates[currency_low]))
             ts = response_timestamp
             source = "coingecko"
         else:

--- a/main/tasks.py
+++ b/main/tasks.py
@@ -2691,18 +2691,25 @@ def fetch_latest_bch_fiat_prices(currencies=None):
         currencies_lower.append("usd")
     vs_currencies = ",".join(currencies_lower)
 
-    resp = requests.get(
-        f"https://pro-api.coingecko.com/api/v3/simple/price/?ids=bitcoin-cash&vs_currencies={vs_currencies}",
-        timeout=15,
-        headers={"x-cg-pro-api-key": settings.COINGECKO_API_KEY},
-    )
+    try:
+        resp = requests.get(
+            f"https://pro-api.coingecko.com/api/v3/simple/price/?ids=bitcoin-cash&vs_currencies={vs_currencies}",
+            timeout=15,
+            headers={"x-cg-pro-api-key": settings.COINGECKO_API_KEY},
+        )
+        resp.raise_for_status()
+        response_data = resp.json()
+    except (requests.RequestException, ValueError) as e:
+        LOGGER.error(f"CoinGecko fetch failed for currencies {vs_currencies}: {e}")
+        raise
+
     response_timestamp = timezone.now()
     date_header = resp.headers.get("Date")
     if date_header:
         response_timestamp = timezone.datetime.strptime(
             date_header, "%a, %d %b %Y %H:%M:%S %Z"
         ).replace(tzinfo=pytz.UTC)
-    rates = resp.json().get("bitcoin-cash", {})
+    rates = response_data.get("bitcoin-cash", {})
 
     results = []
     for currency in currencies:
@@ -2716,8 +2723,11 @@ def fetch_latest_bch_fiat_prices(currencies=None):
                 continue
             if isinstance(yadio, dict) and "rate" in yadio:
                 price_value = Decimal(str(yadio["rate"])) * usd_rate
-                yadio_ts = yadio.get("timestamp") or response_timestamp.timestamp()
-                ts = timezone.datetime.fromtimestamp(yadio_ts / 1000, tz=pytz.UTC)
+                yadio_ts = yadio.get("timestamp")
+                if yadio_ts:
+                    ts = timezone.datetime.fromtimestamp(yadio_ts / 1000, tz=pytz.UTC)
+                else:
+                    ts = response_timestamp
                 source = "coingecko-yadio"
             else:
                 continue

--- a/main/tasks.py
+++ b/main/tasks.py
@@ -2642,51 +2642,98 @@ def resolve_wallet_history_usd_values(txid=None, is_contract=False):
 
     return txids_updated
 
+def _get_active_wallet_currencies(max_currencies=16, cache_ttl=3600):
+    """Return currencies used by recently-active wallets, cached in Redis for 1 hour."""
+    cache_key = "active_wallet_currencies"
+    cached = REDIS_STORAGE.get(cache_key)
+    if cached:
+        currencies = json.loads(cached.decode())
+        if isinstance(currencies, list) and currencies:
+            return currencies
+
+    recent = timezone.now() - timezone.timedelta(days=30)
+    active_wallets = WalletHistory.objects.filter(
+        tx_timestamp__gte=recent,
+    ).values_list("wallet__wallet_hash", flat=True).distinct()
+
+    currency_counts = WalletPreferences.objects.filter(
+        wallet__wallet_hash__in=active_wallets,
+    ).exclude(
+        selected_currency=""
+    ).values("selected_currency").annotate(
+        count=models.Count("selected_currency")
+    ).order_by("-count").values_list("selected_currency", flat=True)[:max_currencies]
+
+    currencies = [c.upper().strip() for c in currency_counts if c.strip()]
+    if "USD" not in currencies:
+        currencies.insert(0, "USD")
+
+    REDIS_STORAGE.set(cache_key, json.dumps(currencies), ex=cache_ttl)
+    return currencies
+
+
 @shared_task(queue='wallet_history_2', max_retries=3)
-def fetch_latest_usd_price():
-    CURRENCY = "USD"
+def fetch_latest_bch_fiat_prices(currencies=None):
     RELATIVE_CURRENCY = "BCH"
-    to_timestamp = timezone.now()
-    from_timestamp = to_timestamp - timezone.timedelta(minutes=10)
-    coingecko_resp = requests.get(
-        # "https://api.coingecko.com/api/v3/coins/bitcoin-cash/market_chart/range?" + \
-        "https://pro-api.coingecko.com/api/v3/coins/bitcoin-cash/market_chart/range?" + \
-        f"vs_currency={CURRENCY}" + \
-        f"&from={from_timestamp.timestamp()}" + \
-        f"&to={to_timestamp.timestamp()}",
-        headers={
-            'x-cg-pro-api-key': settings.COINGECKO_API_KEY
-        }
+    if not currencies:
+        currencies = _get_active_wallet_currencies()
+    elif isinstance(currencies, str):
+        currencies = [c.strip().upper() for c in currencies.split(",") if c.strip()]
+
+    currencies_lower = [c.lower() for c in currencies if c]
+    if "usd" not in currencies_lower:
+        currencies_lower.append("usd")
+    vs_currencies = ",".join(currencies_lower)
+
+    resp = requests.get(
+        f"https://pro-api.coingecko.com/api/v3/simple/price/?ids=bitcoin-cash&vs_currencies={vs_currencies}",
+        timeout=15,
+        headers={"x-cg-pro-api-key": settings.COINGECKO_API_KEY},
     )
+    response_timestamp = timezone.datetime.strptime(
+        resp.headers["Date"], "%a, %d %b %Y %H:%M:%S %Z"
+    ).replace(tzinfo=pytz.UTC)
+    rates = resp.json().get("bitcoin-cash", {})
 
-    coingecko_prices_list = None
-    try:
-        response_data = coingecko_resp.json()
-        if isinstance(response_data, dict) and "prices" in response_data:
-            coingecko_prices_list = response_data.get("prices", [])
-    except json.decoder.JSONDecodeError:
-        pass
+    results = []
+    for currency in currencies:
+        currency_low = currency.lower()
+        if currency_low == "ars":
+            usd_rate = Decimal(rates.get("usd", 0))
+            yadio = requests.get(f"https://api.yadio.io/rate/{currency_low}/usd", timeout=15).json()
+            if isinstance(yadio, dict) and "rate" in yadio:
+                price_value = Decimal(yadio["rate"]) * usd_rate
+                ts = timezone.datetime.fromtimestamp(yadio.get("timestamp", 0) / 1000, tz=pytz.UTC)
+                source = "coingecko-yadio"
+            else:
+                continue
+        elif currency_low in rates:
+            price_value = Decimal(rates[currency_low])
+            ts = response_timestamp
+            source = "coingecko"
+        else:
+            continue
 
-    asset_prices = []
-    for coingecko_price_data in coingecko_prices_list:
-        timestamp = coingecko_price_data[0]/1000
-        timestamp_obj = timezone.datetime.fromtimestamp(timestamp).replace(tzinfo=pytz.UTC)
-        price_value = Decimal(coingecko_price_data[1])
-        instance, created = AssetPriceLog.objects.update_or_create(
-            currency=CURRENCY,
+        instance, _ = AssetPriceLog.objects.update_or_create(
+            currency=currency,
             relative_currency=RELATIVE_CURRENCY,
-            timestamp=timestamp_obj,
-            source="coingecko",
-            defaults={ "price_value": price_value }
+            timestamp=ts,
+            source=source,
+            defaults={"price_value": price_value},
         )
-        asset_prices.append({
+        results.append({
             "currency": instance.currency,
             "timestamp": instance.timestamp,
             "source": instance.source,
             "price_value": instance.price_value,
         })
 
-    return asset_prices
+    return results
+
+
+@shared_task(queue='wallet_history_2', max_retries=3)
+def fetch_latest_usd_price():
+    return fetch_latest_bch_fiat_prices(currencies=["USD"])
 
 @shared_task(queue='wallet_history_2', max_retries=3)
 def parse_wallet_history_market_values(wallet_history_id):

--- a/watchtower/settings.py
+++ b/watchtower/settings.py
@@ -375,8 +375,8 @@ CELERY_BEAT_SCHEDULE = {
         "task": "main.tasks.resolve_wallet_history_usd_values",
         "schedule": 60 * 2,
     },
-    "fetch_latest_usd_price": {
-        "task": "main.tasks.fetch_latest_usd_price",
+    "fetch_latest_bch_fiat_prices": {
+        "task": "main.tasks.fetch_latest_bch_fiat_prices",
         "schedule": 60 * 2,
     },
     # 'preload_smartbch_blocks': {


### PR DESCRIPTION
## Summary

Generalizes the periodic BCH price fetch from USD-only to support multiple fiat currencies, with automatic detection of which currencies are actually used by active wallets.

## Changes

- **fetch_latest_bch_fiat_prices** (new task) — generalized task replacing the USD-only fetch_latest_usd_price. Accepts an optional currency list; when omitted, auto-detects currencies from the DB.
- **_get_active_wallet_currencies** (new helper) — queries WalletPreferences for wallets active in the last 30 days, picks the top 16 most common currencies, caches the result in Redis for 1 hour. USD always guaranteed first.
- **fetch_latest_usd_price** — kept as a thin backward-compatible wrapper.
- Switched from per-currency market_chart/range calls to a single simple/price call for all currencies.
- Celery beat schedule runs every 2 minutes with no static currency list.

## Motivation

Previously, only USD/BCH prices were fetched at regular intervals. Other currencies were fetched on-demand, which could cause stale prices and contribute to the exchange rate discrepancies between Paytaca and other wallets.