### PR TITLE
Fix token address subscription retention and notification matching

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -243,11 +243,13 @@ class Address(PostgresModel):
             if is_slp_address(self.address):
                 wallet.wallet_type = 'slp'
             elif is_bch_address(self.address) or is_token_address(self.address):
+                original_address = self.address
                 if is_token_address(self.address):
-                    self.address = bch_address_converter(self.address, to_token_addr=False)
-                    self.token_address = self.address
+                    # Keep the token-form address for lookup while storing the BCH form canonically.
+                    self.address = bch_address_converter(original_address, to_token_addr=False)
+                    self.token_address = original_address
                 else:
-                    self.token_address = bch_address_converter(self.address)
+                    self.token_address = bch_address_converter(original_address)
 
                 wallet.wallet_type = 'bch'
             elif re.match("0x[0-9a-f]{40}", self.address, re.IGNORECASE):

--- a/main/serializers/serializer_live_updates.py
+++ b/main/serializers/serializer_live_updates.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django.db.models import Q
 
 from main.models import Address, Subscription
 
@@ -15,7 +16,8 @@ class LiveUpdatesPaymentSerializer(serializers.Serializer):
     update_type = serializers.ChoiceField(choices=LIVE_UPDATES_PAYMENT_TYPES)
 
     def validate_address(self, value):
-        address = Address.objects.filter(address=value)
+        # Accept either the canonical BCH address or the preserved token-address form.
+        address = Address.objects.filter(Q(address=value) | Q(token_address=value))
         if address.exists():
             subscription = Subscription.objects.filter(address=address.first())
             if subscription.exists():

--- a/main/tasks.py
+++ b/main/tasks.py
@@ -345,9 +345,12 @@ def save_record(
         value                : value of transaction (amount = value in BCH, value = varies on tokens)
     """
 
-    subscription = Subscription.objects.filter(
-        address__address=transaction_address             
-    )
+    # Treat the canonical BCH form and the preserved token-address form as the same subscription target.
+    matched_address = Address.objects.filter(
+        Q(address=transaction_address) | Q(token_address=transaction_address)
+    ).first()
+
+    subscription = Subscription.objects.filter(address=matched_address) if matched_address else Subscription.objects.none()
 
     # We are only tracking outputs of either subscribed addresses or those of transactions
     # that spend previous transactions with outputs involving tracked addresses
@@ -359,7 +362,10 @@ def save_record(
     LOGGER.info(f'Saving txid: {transactionid} | #{index} | {transaction_address}\nTriggered from {trigger_info}')
     rampp2p_utils.process_transaction(transactionid, transaction_address, inputs=inputs)
 
-    address_obj, _ = Address.objects.get_or_create(address=transaction_address)
+    if matched_address:
+        address_obj = matched_address
+    else:
+        address_obj, _ = Address.objects.get_or_create(address=transaction_address)
 
     try:
         index = int(index)


### PR DESCRIPTION
## Description
Subscribing to a BCH address or its token-address counterpart should be equivalent — one subscription should be enough to receive webhook notifications regardless of which address form a transaction uses. In practice, this was not working correctly for CashToken and NFT transfers sent to token addresses.

There were two root causes:

1. `Address.save()` was overwriting `token_address` with the already-converted BCH form instead of preserving the original token-address input, so the token form was silently lost after save.
2. The transaction processor and live-update validation were only matching subscriptions by the canonical `address` field, so even if a token-address subscription was accepted by the endpoint, it would not be found when a transaction arrived addressed to the token form.

Wallet history and the UI were unaffected because that path only needs the canonical address row and wallet association — which is why NFTs still appeared in the wallet UI even though webhook notifications were not firing.

This fix:
- Preserves the original token-address form on `Address` records instead of overwriting it
- Makes live-update validation resolve subscriptions through either the canonical or token address form
- Makes the transaction processor resolve subscription matches through either stored address form before deciding no subscription exists


## Screenshots (if applicable):
N/A


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
How Has This Been Tested?

Suggested reproduction steps:
1. Subscribe a webhook using **either** the canonical BCH address **or** its token-address counterpart — subscribing once to either form is sufficient
2. Confirm that only one `Address` record and one `Subscription` row are stored on the server
3. Send an NFT or CashToken to the token-address form
4. Confirm the subscribed server receives the webhook notification
5. Send a transaction to the canonical BCH address form
6. Confirm the subscribed server also receives the webhook notification for that

Will the applied changes affect other areas of the code?
- Canonical address matching behavior is unchanged (fully backward compatible for existing BCH address subscriptions)
- The change is additive: token-address lookups now resolve to the same subscription target instead of being silently dropped
- Existing address rows with a previously missing or incorrect `token_address` value will not be automatically corrected and may need a one-off data migration if historical backfill is required


## @mentions
@joemarct 