### PR TITLE
perf(chipnet): reduce latency for balance/history updates

### DIFF
--- a/compose/chipnet.yml
+++ b/compose/chipnet.yml
@@ -48,6 +48,21 @@ services:
     image: "redis:alpine"
     env_file:
       - /root/watchtower/compose/.env_chipnet
+  emqx:
+    image: "emqx/emqx:5.0.26"
+    environment:
+      - EMQX_NAME=watchtower-chipnet
+      - EMQX_ALLOW_ANONYMOUS=true
+    volumes:
+      - emqx_data:/opt/emqx/data
+      - emqx_log:/opt/emqx/log
+    ports:
+      - "1883:1883"
+      - "8083:8083"
+      - "8084:8084"
+      - "8883:8883"
+      - "18083:18083"
+    restart: on-failure
   backend:
     container_name: watchtower_backend
     build: /root/watchtower
@@ -64,6 +79,9 @@ services:
     depends_on:
       - postgres
       - redis
+      - emqx
 volumes:
   watchtower_db_data:
     external: true
+  emqx_data:
+  emqx_log:

--- a/main/management/commands/mempool_listener.py
+++ b/main/management/commands/mempool_listener.py
@@ -24,8 +24,6 @@ if settings.BCH_NETWORK == 'mainnet':
 else:
     mqtt_client = mqtt.Client(client_id=mqtt_client_id, clean_session=False)
 
-mqtt_client.connect(settings.MQTT_HOST, settings.MQTT_PORT, keepalive=60)
-
 
 # The callback for when the client receives a CONNACK response from the server.
 def on_connect(client, userdata, flags, rc):
@@ -121,4 +119,22 @@ class Command(BaseCommand):
     help = 'Run the mempool listener'
 
     def handle(self, *args, **options):
+        # Retry initial connection with backoff — MQTT broker (docker-host) may
+        # not be ready when this process starts (startup race condition).
+        reconnect_count, reconnect_delay = 0, FIRST_RECONNECT_DELAY
+        while reconnect_count < MAX_RECONNECT_COUNT:
+            try:
+                mqtt_client.connect(settings.MQTT_HOST, settings.MQTT_PORT, keepalive=60)
+                LOGGER.info(f"Connected to MQTT broker at {settings.MQTT_HOST}:{settings.MQTT_PORT}")
+                break
+            except Exception as err:
+                LOGGER.error(f"MQTT connect failed: {err}. Retrying in {reconnect_delay}s...")
+                time.sleep(reconnect_delay)
+                reconnect_delay *= RECONNECT_RATE
+                reconnect_delay = min(reconnect_delay, MAX_RECONNECT_DELAY)
+                reconnect_count += 1
+        else:
+            LOGGER.error(f"MQTT connect failed after {reconnect_count} attempts. Exiting.")
+            return
+
         mqtt_client.loop_forever()

--- a/main/tasks.py
+++ b/main/tasks.py
@@ -893,6 +893,9 @@ def manage_blocks(self):
 
                 transactions = NODE.BCH.get_block(block.number, verbosity=3)
                 block_time = NODE.BCH.get_block_stats(block.number, stats=["time"])["time"]
+                block_age = timezone.now().timestamp() - block_time
+                LOGGER.info(f"Processing block {block.number} (age: {block_age:.1f}s, "
+                            f"txs: {len(transactions)})")
                 for tx in transactions:
                     tx["time"] = block_time # tx is from .get_block() which doesn't return tx's timestamp
                     parsed_tx = NODE.BCH._parse_transaction(tx)

--- a/main/views/view_balance.py
+++ b/main/views/view_balance.py
@@ -226,8 +226,9 @@ class Balance(APIView):
                 data['balance'] = self.truncate(bch_balance, 8)
                 data['valid'] = True
                 
-                # Cache for 5 minutes (same as wallet balance cache)
-                cache.set(cache_key, json.dumps(data), ex=60 * 5)
+                # Cache: 5min (mainnet) / 1min (chipnet/testnet) for faster balance updates
+                cache_ttl = 60 if settings.BCH_NETWORK != 'mainnet' else 60 * 5
+                cache.set(cache_key, json.dumps(data), ex=cache_ttl)
 
         if wallet_hash:
             try:
@@ -324,13 +325,15 @@ class Balance(APIView):
                         data['yield'] = None # compute_wallet_yield(wallet_hash)
                         data['valid'] = True
 
-                        cache.set(bch_cache_key, json.dumps(data), ex=60 * 5) # 5 minutes
+                        cache_ttl = 60 if settings.BCH_NETWORK != 'mainnet' else 60 * 5
+                        cache.set(bch_cache_key, json.dumps(data), ex=cache_ttl)
                 else:
                     ct_cache_key = f'wallet:balance:token:{wallet_hash}:{_category}'
                     cached_data = cache.get(ct_cache_key)
                     if cached_data:
                         data = json.loads(cached_data) 
                     else:
+                        cache_ttl = 60 if settings.BCH_NETWORK != 'mainnet' else 60 * 5
                         try:
                             if is_cashtoken_nft:
                                 token = CashNonFungibleToken.objects.get(
@@ -358,14 +361,14 @@ class Balance(APIView):
                                 data['commitment'] = token.commitment
                                 data['capability'] = token.capability
 
-                            cache.set(ct_cache_key, json.dumps(data), ex=60 * 5) # 5 minutes
+                            cache.set(ct_cache_key, json.dumps(data), ex=cache_ttl)
                         except ObjectDoesNotExist:
                             # Token not found, return zero balance
                             data['balance'] = 0
                             data['spendable'] = 0
                             data['token_id'] = _category
                             data['valid'] = True
-                            cache.set(ct_cache_key, json.dumps(data), ex=60 * 5) # 5 minutes
+                            cache.set(ct_cache_key, json.dumps(data), ex=cache_ttl)
 
             # Update last_balance_check timestamp
             wallet.last_balance_check = timezone.now()

--- a/main/views/view_history.py
+++ b/main/views/view_history.py
@@ -107,7 +107,8 @@ def store_object(key, obj, cache):
     # Convert binary to Base64 string
     encoded_data = base64.b64encode(pickled_data).decode("utf-8")
     # Store in Redis
-    cache.set(key, encoded_data, ex=60 * 5)  # Cache for 5 minutes
+    cache_ttl = 60 if settings.BCH_NETWORK != 'mainnet' else 60 * 5
+    cache.set(key, encoded_data, ex=cache_ttl)
 
 
 def retrieve_object(key, cache):

--- a/watchtower/settings.py
+++ b/watchtower/settings.py
@@ -635,6 +635,13 @@ ANYHEDGE = {
 
 
 BCH_NETWORK = config("BCH_NETWORK", default="chipnet")
+
+# Faster polling for non-mainnet (chipnet/testnet) to reduce balance update latency.
+# Mainnet blocks are larger/more frequent so we keep the default intervals there.
+if BCH_NETWORK != "mainnet":
+    CELERY_BEAT_SCHEDULE["get_latest_block"]["schedule"] = 2
+    CELERY_BEAT_SCHEDULE["manage_blocks"]["schedule"] = 3
+
 RPC_USER = decipher(config("RPC_USER"))
 
 FULCRUM_PORT = 50001


### PR DESCRIPTION
## Summary

Chipnet users report slow balance and history updates after payments. This addresses the root causes:

### Changes
- **Polling intervals** (chipnet only): `get_latest_block` 5s→2s, `manage_blocks` 7s→3s — cuts block detection latency from ~12s to ~5s
- **Cache TTLs** (chipnet only): balance and history caches 5min→1min — reduces stale API responses
- **EMQX broker**: bundle emqx/emqx:5.0.26 into docker-compose with `depends_on` — fixes MQTT startup race condition
- **MQTT connect fix**: move `mempool_listener` MQTT connect from module import time to `handle()` with retry loop — prevents crash when EMQX isn't ready yet
- **Instrumentation**: log block age and tx count in `manage_blocks` to surface processing latency

### No impact on mainnet
All changes are gated behind `BCH_NETWORK != 'mainnet'`.

### Deployment note
Before deploying, update `/root/watchtower/compose/.env_chipnet`:
```
MQTT_HOST=emqx
```