### PR TITLE
Resource usage optimizations

### DIFF
--- a/paytacagifts/tasks.py
+++ b/paytacagifts/tasks.py
@@ -62,8 +62,7 @@ def check_unclaimed_gifts():
     for tx in spending_txs:
         spending_by_txid.setdefault(tx['txid'], []).append(tx)
 
-    gifts_to_update = []
-
+    gift_wallet_map = {}
     for gift in funded_gifts:
         funding = funding_by_address.get(gift.address)
         if not funding:
@@ -75,18 +74,42 @@ def check_unclaimed_gifts():
             if not wallet_hash:
                 continue
 
-            claim = Claim.objects.filter(
-                gift=gift,
-                wallet__wallet_hash=wallet_hash
-            ).order_by('-date_created').first()
+            key = (gift.id, wallet_hash)
+            if key not in gift_wallet_map:
+                gift_wallet_map[key] = (tx['tx_timestamp'], funding['spending_txid'], gift)
 
-            if claim:
-                gift.date_claimed = tx['tx_timestamp']
-                gift.claim_txid = funding['spending_txid']
-                gifts_to_update.append(gift)
-                claim.succeeded = True
-                claim.save()
-                break
+    if not gift_wallet_map:
+        return
+
+    gift_ids = [k[0] for k in gift_wallet_map]
+    wallet_hashes = [k[1] for k in gift_wallet_map]
+
+    all_claims = Claim.objects.filter(
+        gift_id__in=gift_ids,
+        wallet__wallet_hash__in=wallet_hashes
+    ).select_related('wallet').order_by('-date_created')
+
+    claim_map = {}
+    for claim in all_claims:
+        key = (claim.gift_id, claim.wallet.wallet_hash)
+        if key not in claim_map:
+            claim_map[key] = claim
+
+    gifts_to_update = []
+    claims_to_update = []
+
+    for (gift_id, wallet_hash), (tx_timestamp, spending_txid, gift) in gift_wallet_map.items():
+        claim = claim_map.get((gift_id, wallet_hash))
+        if not claim:
+            continue
+
+        gift.date_claimed = tx_timestamp
+        gift.claim_txid = spending_txid
+        gifts_to_update.append(gift)
+        claim.succeeded = True
+        claims_to_update.append(claim)
 
     if gifts_to_update:
         Gift.objects.bulk_update(gifts_to_update, ['date_claimed', 'claim_txid'])
+    if claims_to_update:
+        Claim.objects.bulk_update(claims_to_update, ['succeeded'])

--- a/paytacagifts/tasks.py
+++ b/paytacagifts/tasks.py
@@ -5,36 +5,88 @@ from main.models import Transaction
 
 @shared_task(queue='monitor-gifts')
 def check_unfunded_gifts():
-    unfunded_gifts = Gift.objects.filter(date_funded__isnull=True)
+    unfunded_gifts = list(Gift.objects.filter(date_funded__isnull=True))
+    if not unfunded_gifts:
+        return
+
+    addresses = [g.address for g in unfunded_gifts if g.address]
+    if not addresses:
+        return
+
+    funding_txs = Transaction.objects.filter(
+        address__address__in=addresses
+    ).values('address__address', 'date_created')
+
+    tx_map = {tx['address__address']: tx['date_created'] for tx in funding_txs}
+
     for gift in unfunded_gifts:
-        funding_check = Transaction.objects.filter(address__address=gift.address)
-        if funding_check.exists():
-            funding_tx = funding_check.first()
-            gift.date_funded = funding_tx.date_created
-            gift.save()
+        if gift.address in tx_map:
+            gift.date_funded = tx_map[gift.address]
+
+    updated = [g for g in unfunded_gifts if g.date_funded is not None]
+    if updated:
+        Gift.objects.bulk_update(updated, ['date_funded'])
 
 
 @shared_task(queue='monitor-gifts')
 def check_unclaimed_gifts():
-    funded_gifts = Gift.objects.filter(date_funded__isnull=False)
-    for gift in funded_gifts:
-        funding_tx = Transaction.objects.filter(
-            address__address=gift.address
-        ).first()
-        if funding_tx:
-            if funding_tx.spent:
-                # Determine which claim succeeded
-                txs = Transaction.objects.filter(txid=funding_tx.spending_txid)
-                for tx in txs:
-                    if tx.wallet:
-                        claim_check = Claim.objects.filter(gift=gift, wallet__wallet_hash=tx.wallet.wallet_hash)
-                        if claim_check.exists():
-                            # Udpate gift fields
-                            gift.date_claimed = tx.tx_timestamp
-                            gift.claim_txid = funding_tx.spending_txid
-                            gift.save()
+    funded_gifts = list(Gift.objects.filter(
+        date_funded__isnull=False,
+        date_claimed__isnull=True
+    ))
+    if not funded_gifts:
+        return
 
-                            # Mark claim as succeeded
-                            claim = claim_check.latest('date_created')
-                            claim.succeeded = True
-                            claim.save()
+    addresses = [g.address for g in funded_gifts if g.address]
+    if not addresses:
+        return
+
+    funding_txs = Transaction.objects.filter(
+        address__address__in=addresses,
+        spent=True
+    ).values('address__address', 'spending_txid')
+
+    funding_by_address = {tx['address__address']: tx for tx in funding_txs}
+    if not funding_by_address:
+        return
+
+    spending_txids = [tx['spending_txid'] for tx in funding_txs if tx['spending_txid']]
+    if not spending_txids:
+        return
+
+    spending_txs = Transaction.objects.filter(
+        txid__in=spending_txids
+    ).select_related('wallet').values('txid', 'wallet__wallet_hash', 'tx_timestamp')
+
+    spending_by_txid = {}
+    for tx in spending_txs:
+        spending_by_txid.setdefault(tx['txid'], []).append(tx)
+
+    gifts_to_update = []
+
+    for gift in funded_gifts:
+        funding = funding_by_address.get(gift.address)
+        if not funding:
+            continue
+
+        spend_txs = spending_by_txid.get(funding['spending_txid'], [])
+        for tx in spend_txs:
+            wallet_hash = tx.get('wallet__wallet_hash')
+            if not wallet_hash:
+                continue
+
+            claim = Claim.objects.filter(
+                gift=gift,
+                wallet__wallet_hash=wallet_hash
+            ).order_by('-date_created').first()
+
+            if claim:
+                gift.date_claimed = tx['tx_timestamp']
+                gift.claim_txid = funding['spending_txid']
+                gifts_to_update.append(gift)
+                claim.succeeded = True
+                claim.save()
+                break
+
+    if gifts_to_update:
+        Gift.objects.bulk_update(gifts_to_update, ['date_claimed', 'claim_txid'])

--- a/rampp2p/tasks/task_marketprice.py
+++ b/rampp2p/tasks/task_marketprice.py
@@ -4,7 +4,6 @@ from celery import shared_task
 from django.utils import timezone
 
 from main.models import AssetPriceLog
-from main.utils.market_price import get_latest_bch_rates
 import rampp2p.models as models
 from rampp2p.utils.websocket import send_market_price
 
@@ -15,8 +14,9 @@ logger = logging.getLogger(__name__)
 def update_market_prices():
     """
     Updates the market prices for subscribed fiat currencies.
-    Reads from AssetPriceLog DB cache first (kept warm by fetch_latest_bch_fiat_prices).
-    Falls back to CoinGecko for any currencies missing from cache.
+    Reads from AssetPriceLog DB cache kept warm by fetch_latest_bch_fiat_prices.
+    Does NOT call CoinGecko directly — that is the sole responsibility of
+    fetch_latest_bch_fiat_prices (runs every 25s on wallet_history_2 queue).
     """
 
     try:
@@ -26,7 +26,7 @@ def update_market_prices():
             return
 
         now = timezone.now()
-        window = timedelta(seconds=60)
+        window = timedelta(seconds=180)
 
         price_logs = AssetPriceLog.objects.filter(
             currency__in=currencies,
@@ -42,17 +42,7 @@ def update_market_prices():
 
         missing = [c for c in currencies if c not in found]
         if missing:
-            logger.warning(
-                "DB cache miss for %d currencies: %s, falling back to CoinGecko",
-                len(missing), missing,
-            )
-            try:
-                bch_prices = get_latest_bch_rates(missing)
-                for currency, data in bch_prices.items():
-                    price_value, _, _ = data
-                    found[currency.upper()] = price_value
-            except Exception as e:
-                logger.error("CoinGecko fallback also failed for %s: %s", missing, e)
+            logger.warning("Cache miss for %d currencies: %s — skipping until next cycle", len(missing), missing)
 
         for currency, price_value in found.items():
             rate, _ = models.MarketPrice.objects.get_or_create(currency=currency)

--- a/supervisor/blockscan.conf
+++ b/supervisor/blockscan.conf
@@ -26,7 +26,7 @@ stopasgroup = true
 
 
 [program:celery_transaction_filter]
-command=celery -A watchtower worker -l INFO -Ofair -Q transaction_filter --autoscale=1,4 --max-tasks-per-child=200 --max-memory-per-child 250000
+command=celery -A watchtower worker -l INFO -Ofair -Q transaction_filter --autoscale=1,2 --max-tasks-per-child=200 --max-memory-per-child 250000
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -35,7 +35,7 @@ stopasgroup=true
 
 
 [program:celery_save_record]
-command=celery -A watchtower worker -l INFO -Ofair -Q save_record --max-tasks-per-child=200 --autoscale=1,3 --max-memory-per-child 250000
+command=celery -A watchtower worker -l INFO -Ofair -Q save_record --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -98,7 +98,7 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 
 [program:celery_slpdbquery_transactions]
-command=celery -A watchtower worker -l INFO -Ofair -Q slpdbquery_transactions --max-tasks-per-child=200 --autoscale=1,3 --max-memory-per-child 250000
+command=celery -A watchtower worker -l INFO -Ofair -Q slpdbquery_transactions --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
@@ -106,7 +106,7 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 
 [program:celery_bitdbquery_transactions]
-command=celery -A watchtower worker -l INFO -Ofair -Q bitdbquery_transactions --max-tasks-per-child=200 --autoscale=1,3 --max-memory-per-child 250000
+command=celery -A watchtower worker -l INFO -Ofair -Q bitdbquery_transactions --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/supervisor/notifications.conf
+++ b/supervisor/notifications.conf
@@ -17,7 +17,7 @@ serverurl=unix:///var/run/supervisor.sock
 
 
 [program:celery_client_acknowledgement]
-command = celery -A watchtower worker -l INFO -Ofair -Q client_acknowledgement --autoscale=1,8 --max-tasks-per-child=100
+command = celery -A watchtower worker -l INFO -Ofair -Q client_acknowledgement --autoscale=1,2 --max-tasks-per-child=100
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/supervisor/notifications.conf
+++ b/supervisor/notifications.conf
@@ -17,7 +17,7 @@ serverurl=unix:///var/run/supervisor.sock
 
 
 [program:celery_client_acknowledgement]
-command = celery -A watchtower worker -l INFO -Ofair -Q client_acknowledgement --autoscale=1,2 --max-tasks-per-child=100
+command = celery -A watchtower worker -l INFO -Ofair -Q client_acknowledgement --autoscale=1,3 --max-tasks-per-child=100
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/supervisor/webserver.conf
+++ b/supervisor/webserver.conf
@@ -124,7 +124,7 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 
 [program:celery_post_save_record]
-command=celery -A watchtower worker -n worker5 -l INFO -Ofair -Q post_save_record --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker5 -l INFO -Ofair -Q post_save_record --max-tasks-per-child=200 --autoscale=1,3 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/supervisor/webserver.conf
+++ b/supervisor/webserver.conf
@@ -61,7 +61,7 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 
 [program:celery_save_record]
-command=celery -A watchtower worker -n worker4 -l INFO -Ofair -Q save_record --max-tasks-per-child=200 --autoscale=1,4 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker4 -l INFO -Ofair -Q save_record --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -97,7 +97,7 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 
 [program:celery_contract_history]
-command=celery -A watchtower worker -n contract_history.worker -l INFO -Ofair -Q contract_history --max-tasks-per-child=200 --autoscale=1,3 --max-memory-per-child 250000
+command=celery -A watchtower worker -n contract_history.worker -l INFO -Ofair -Q contract_history --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -106,7 +106,7 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 
 [program:celery_wallet_history_1]
-command=celery -A watchtower worker -n worker6 -l INFO -Ofair -Q wallet_history_1 --max-tasks-per-child=200 --autoscale=1,4 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker6 -l INFO -Ofair -Q wallet_history_1 --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -115,7 +115,7 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 
 [program:celery_wallet_history_2]
-command=celery -A watchtower worker -n worker7 -l INFO -Ofair -Q wallet_history_2 --max-tasks-per-child=200 --autoscale=1,4 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker7 -l INFO -Ofair -Q wallet_history_2 --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -124,7 +124,7 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 
 [program:celery_post_save_record]
-command=celery -A watchtower worker -n worker5 -l INFO -Ofair -Q post_save_record --max-tasks-per-child=200 --autoscale=1,6 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker5 -l INFO -Ofair -Q post_save_record --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/supervisor/webserver.conf
+++ b/supervisor/webserver.conf
@@ -34,7 +34,7 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 
 [program:rampp2p__marketprices]
-command = celery -A watchtower worker -n rampp2p__marketprices -l INFO -Ofair -Q rampp2p__marketprices
+command = celery -A watchtower worker -n rampp2p__marketprices -l INFO -Ofair -Q rampp2p__marketprices --max-tasks-per-child=200 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -339,7 +339,7 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 
 [program:rampp2p__marketprices]
-command = celery -A watchtower worker -n rampp2p__marketprices -l INFO -Ofair -Q rampp2p__marketprices
+command = celery -A watchtower worker -n rampp2p__marketprices -l INFO -Ofair -Q rampp2p__marketprices --max-tasks-per-child=200 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -37,7 +37,7 @@ stopasgroup=true
 
 
 [program:celery_client_acknowledgement]
-command=celery -A watchtower worker -n worker1 -l INFO -Ofair -Q client_acknowledgement --autoscale=1,4 --max-tasks-per-child=200 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker1 -l INFO -Ofair -Q client_acknowledgement --autoscale=1,2 --max-tasks-per-child=200 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
@@ -84,7 +84,7 @@ stopasgroup=true
 
 
 [program:celery_save_record]
-command=celery -A watchtower worker -n worker4 -l INFO -Ofair -Q save_record --max-tasks-per-child=200 --autoscale=1,4 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker4 -l INFO -Ofair -Q save_record --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -94,7 +94,7 @@ stopasgroup=true
 
 
 [program:celery_post_save_record]
-command=celery -A watchtower worker -n worker5 -l INFO -Ofair -Q post_save_record --max-tasks-per-child=200 --autoscale=1,6 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker5 -l INFO -Ofair -Q post_save_record --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -104,7 +104,7 @@ stopasgroup=true
 
 
 [program:celery_contract_history]
-command=celery -A watchtower worker -n contract_history.worker -l INFO -Ofair -Q contract_history --max-tasks-per-child=200 --autoscale=1,3 --max-memory-per-child 250000
+command=celery -A watchtower worker -n contract_history.worker -l INFO -Ofair -Q contract_history --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -114,7 +114,7 @@ stopasgroup=true
 
 
 [program:celery_wallet_history_1]
-command=celery -A watchtower worker -n worker6 -l INFO -Ofair -Q wallet_history_1 --max-tasks-per-child=200 --autoscale=1,4 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker6 -l INFO -Ofair -Q wallet_history_1 --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -124,7 +124,7 @@ stopasgroup=true
 
 
 [program:celery_wallet_history_2]
-command=celery -A watchtower worker -n worker7 -l INFO -Ofair -Q wallet_history_2 --max-tasks-per-child=200 --autoscale=1,3 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker7 -l INFO -Ofair -Q wallet_history_2 --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -154,7 +154,7 @@ stopasgroup=true
 
 
 [program:celery_query_transaction]
-command=celery -A watchtower worker -n worker10 -l INFO -Ofair -Q query_transaction --max-tasks-per-child=200 --autoscale=1,4 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker10 -l INFO -Ofair -Q query_transaction --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -163,7 +163,7 @@ stderr_logfile_maxbytes=0
 stopasgroup=true
 
 [program:celery_get_utxos]
-command=celery -A watchtower worker -n worker11 -l INFO -Ofair -Q get_utxos --max-tasks-per-child=200 --autoscale=1,3 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker11 -l INFO -Ofair -Q get_utxos --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -183,7 +183,7 @@ stopasgroup=true
 
 
 [program:celery_txn_broadcast]
-command=celery -A watchtower worker -n worker13 -l INFO -Ofair -Q broadcast --max-tasks-per-child=200 --autoscale=1,4 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker13 -l INFO -Ofair -Q broadcast --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -193,7 +193,7 @@ stopasgroup=true
 
 
 [program:celery_rescan_utxos]
-command=celery -A watchtower worker -n worker15 -l INFO -Ofair -Q rescan_utxos --max-tasks-per-child=200 --autoscale=1,3 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker15 -l INFO -Ofair -Q rescan_utxos --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -223,7 +223,7 @@ stopasgroup=true
 
 
 [program:stablehedge_tasks]
-command=celery -A watchtower worker -n worker27 -l INFO -Ofair -Q stablehedge__treasury_contract --max-tasks-per-child=200 --autoscale=1,4 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker27 -l INFO -Ofair -Q stablehedge__treasury_contract --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -283,7 +283,7 @@ stopasgroup=true
 
 
 [program:mempool_processing_fast]
-command=celery -A watchtower worker -n worker26b -l INFO -Ofair -Q mempool_processing_fast --max-tasks-per-child=500 --autoscale=1,6 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker26b -l INFO -Ofair -Q mempool_processing_fast --max-tasks-per-child=500 --autoscale=1,2 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -37,7 +37,7 @@ stopasgroup=true
 
 
 [program:celery_client_acknowledgement]
-command=celery -A watchtower worker -n worker1 -l INFO -Ofair -Q client_acknowledgement --autoscale=1,2 --max-tasks-per-child=200 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker1 -l INFO -Ofair -Q client_acknowledgement --autoscale=1,3 --max-tasks-per-child=200 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
@@ -94,7 +94,7 @@ stopasgroup=true
 
 
 [program:celery_post_save_record]
-command=celery -A watchtower worker -n worker5 -l INFO -Ofair -Q post_save_record --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker5 -l INFO -Ofair -Q post_save_record --max-tasks-per-child=200 --autoscale=1,3 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
@@ -283,7 +283,7 @@ stopasgroup=true
 
 
 [program:mempool_processing_fast]
-command=celery -A watchtower worker -n worker26b -l INFO -Ofair -Q mempool_processing_fast --max-tasks-per-child=500 --autoscale=1,2 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker26b -l INFO -Ofair -Q mempool_processing_fast --max-tasks-per-child=500 --autoscale=1,3 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -253,7 +253,7 @@ stopasgroup=true
 
 
 [program:paytacagifts__monitor]
-command=celery -A watchtower worker -n worker24 -l INFO -Ofair -Q monitor-gifts --max-tasks-per-child=200 --autoscale=1,2 --max-memory-per-child 250000
+command=celery -A watchtower worker -n worker24 -l INFO -Ofair -Q monitor-gifts --max-tasks-per-child=200 --concurrency=1 --max-memory-per-child 250000
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/watchtower/settings.py
+++ b/watchtower/settings.py
@@ -402,7 +402,7 @@ CELERY_BEAT_SCHEDULE = {
     "update_shift_status": {"task": "ramp.tasks.update_shift_status", "schedule": 60},
     "update_market_prices": {
         "task": "rampp2p.tasks.task_marketprice.update_market_prices",
-        "schedule": 15,  # run every 15 seconds
+        "schedule": 60,
     },
     "check_unfunded_gifts": {
         "task": "paytacagifts.tasks.check_unfunded_gifts",

--- a/watchtower/settings.py
+++ b/watchtower/settings.py
@@ -406,11 +406,11 @@ CELERY_BEAT_SCHEDULE = {
     },
     "check_unfunded_gifts": {
         "task": "paytacagifts.tasks.check_unfunded_gifts",
-        "schedule": 5,
+        "schedule": 60,
     },
     "check_unclaimed_gifts": {
         "task": "paytacagifts.tasks.check_unclaimed_gifts",
-        "schedule": 7,
+        "schedule": 60,
     },
     "bulk_rebroadcast": {"task": "main.tasks.bulk_rebroadcast", "schedule": 30},
     "cancel_expired_orders": {


### PR DESCRIPTION
## Summary

Reduces CPU and memory pressure across Celery workers by fixing N+1 query patterns, eliminating redundant API calls, reducing aggressive schedules, and capping autoscale ceilings.

## Changes

### CPU optimizations
- **monitor-gifts**: Eliminated N+1 query patterns, replaced with batched lookups and `bulk_update`. Reduced schedule from 5s/7s to 60s.
- **rampp2p__marketprices**: Removed redundant CoinGecko fallback — `fetch_latest_bch_fiat_prices` is now the single source of truth. Reduced schedule from 15s to 60s.

### Memory optimizations
- Reduced autoscale ceilings across all supervisor configs. Previously ranged up to 1,6/1,8 — now capped at 1,2 for most workers, with 1,3 for `post_save_record`, `mempool_processing_fast`, and `client_acknowledgement`. This reduces worst-case Celery memory from ~12.4GB to ~5.5GB.

### Hygiene
- Added missing `--max-tasks-per-child` and `--max-memory-per-child` to several workers that lacked them.
- Pinned `monitor-gifts` concurrency to 1 (was autoscale 1,2).