### PR TITLE
feat: vault address endpoint returns merchant name/logo

### DIFF
--- a/paytacapos/serializers.py
+++ b/paytacapos/serializers.py
@@ -987,7 +987,7 @@ class WalletLatestMerchantIndexResponseSerializer(serializers.Serializer):
 
 class MerchantVaultAddressSerializer(serializers.Serializer):
     address = serializers.CharField()
-    posid = serializers.IntegerField()
+    posid = serializers.IntegerField(required=False)
 
 
 class LatestPosIdSerializer(serializers.Serializer):

--- a/paytacapos/serializers.py
+++ b/paytacapos/serializers.py
@@ -721,7 +721,8 @@ class MerchantListSerializer(serializers.ModelSerializer):
             "last_update",
             "branch_count",
             "pos_device_count",
-            "nfc_enabled"
+            "nfc_enabled",
+            "verified"
         ]
 
     def get_receiving_address(self, obj):

--- a/paytacapos/serializers.py
+++ b/paytacapos/serializers.py
@@ -990,6 +990,13 @@ class MerchantVaultAddressSerializer(serializers.Serializer):
     posid = serializers.IntegerField(required=False)
 
 
+class MerchantVaultAddressResponseSerializer(MerchantListSerializer):
+    logo_data = serializers.CharField(read_only=True, required=False)
+
+    class Meta(MerchantListSerializer.Meta):
+        fields = MerchantListSerializer.Meta.fields + ['logo_data']
+
+
 class LatestPosIdSerializer(serializers.Serializer):
     wallet_hash = serializers.CharField()
 

--- a/paytacapos/views.py
+++ b/paytacapos/views.py
@@ -427,11 +427,18 @@ class MerchantViewSet(viewsets.ModelViewSet):
             return Response({})
 
         merchant = pos_device.merchant
-        logo_url = f'{settings.DOMAIN}{merchant.logo_60.url}' if merchant.logo_60 else None
+        logo = merchant.logo_60
+        logo_url = f'{settings.DOMAIN}{logo.url}' if logo else None
+        logo_data = None
+        if logo:
+            ext = logo.name.rsplit('.', 1)[-1].lower()
+            mime = 'image/jpeg' if ext in ('jpg', 'jpeg') else f'image/{ext}'
+            logo_data = f'data:{mime};base64,{base64.b64encode(logo.read()).decode()}'
         return Response({
             "merchant": {
                 "name": merchant.name,
                 "logo": logo_url,
+                "logo_data": logo_data,
                 "verified": merchant.verified
             }
         })

--- a/paytacapos/views.py
+++ b/paytacapos/views.py
@@ -435,7 +435,7 @@ class MerchantViewSet(viewsets.ModelViewSet):
         response_data = MerchantVaultAddressResponseSerializer(merchant).data
 
         logo = merchant.logo_60
-        if logo:
+        if logo and logo.size < 512 * 1024:
             try:
                 ext = logo.name.rsplit('.', 1)[-1].lower()
                 if ext in ('jpg', 'jpeg'):
@@ -445,10 +445,12 @@ class MerchantViewSet(viewsets.ModelViewSet):
                 else:
                     mime = f'image/{ext}'
                 logo.seek(0)
-                if logo.size < 512 * 1024:
-                    response_data['logo_data'] = f'data:{mime};base64,{base64.b64encode(logo.read()).decode()}'
+                response_data['logo_data'] = f'data:{mime};base64,{base64.b64encode(logo.read()).decode()}'
             except Exception:
-                pass
+                logger.exception("Failed to encode merchant logo for vault_address")
+                response_data['logo_data'] = None
+        else:
+            response_data['logo_data'] = None
 
         return Response(response_data)
 

--- a/paytacapos/views.py
+++ b/paytacapos/views.py
@@ -1,6 +1,7 @@
 import pickle
 import base64
 import json
+import re
 from django.db.models import (
     F, Value,
     Func,
@@ -305,6 +306,23 @@ class PosDeviceViewSet(
         return Response(serializer.data)
 
 
+POS_ID_MAX_DIGITS = 4
+MIN_POS_ADDRESS_INDEX = 10 ** POS_ID_MAX_DIGITS
+
+
+def get_posid_from_address(address):
+    '''Extract posid from address_path. POS addresses have index >= 10000.'''
+    if not address.address_path:
+        return None
+    match = re.match(r'0/(\d+)', address.address_path)
+    if not match:
+        return None
+    index = int(match.group(1))
+    if index < MIN_POS_ADDRESS_INDEX:
+        return None
+    return index % MIN_POS_ADDRESS_INDEX
+
+
 class MerchantViewSet(viewsets.ModelViewSet):
     http_method_names = ["get", "post", "head", "patch", "delete"]
 
@@ -392,12 +410,20 @@ class MerchantViewSet(viewsets.ModelViewSet):
         address = Address.objects.get(address=serializer.validated_data['address'])
         posid = serializer.validated_data.get('posid')
 
-        qs = PosDevice.objects.filter(wallet_hash=address.wallet.wallet_hash)
-        if posid is not None:
-            qs = qs.filter(posid=posid)
+        if posid is None:
+            posid = get_posid_from_address(address)
+            if posid is None:
+                return Response({})
 
-        pos_device = qs.order_by('-id').first()
-        if not pos_device or not pos_device.merchant:
+        try:
+            pos_device = PosDevice.objects.get(
+                wallet_hash=address.wallet.wallet_hash,
+                posid=posid
+            )
+        except PosDevice.DoesNotExist:
+            return Response({})
+
+        if not pos_device.merchant:
             return Response({})
 
         merchant = pos_device.merchant
@@ -405,7 +431,8 @@ class MerchantViewSet(viewsets.ModelViewSet):
         return Response({
             "merchant": {
                 "name": merchant.name,
-                "logo": logo_url
+                "logo": logo_url,
+                "verified": merchant.verified
             }
         })
 

--- a/paytacapos/views.py
+++ b/paytacapos/views.py
@@ -311,10 +311,11 @@ MIN_POS_ADDRESS_INDEX = 10 ** POS_ID_MAX_DIGITS
 
 
 def get_posid_from_address(address):
-    '''Extract posid from address_path. POS addresses have index >= 10000.'''
+    '''Extract posid from address_path. POS addresses have index >= 10000.
+    Address path format: <change>/<index> where change is 0 (receiving) or 1 (change).'''
     if not address.address_path:
         return None
-    match = re.match(r'0/(\d+)', address.address_path)
+    match = re.match(r'[01]/(\d+)', address.address_path)
     if not match:
         return None
     index = int(match.group(1))
@@ -401,13 +402,17 @@ class MerchantViewSet(viewsets.ModelViewSet):
         response = { 'index': index }
         return Response(response)
 
-    @swagger_auto_schema(method="post", request_body=MerchantVaultAddressSerializer)
+    @swagger_auto_schema(method="post", request_body=MerchantVaultAddressSerializer, responses={ 200: MerchantVaultAddressResponseSerializer })
     @decorators.action(methods=["post"], detail=False)
     def vault_address(self, request, *args, **kwargs):
         serializer = MerchantVaultAddressSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        address = Address.objects.get(address=serializer.validated_data['address'])
+        try:
+            address = Address.objects.get(address=serializer.validated_data['address'])
+        except Address.DoesNotExist:
+            return Response({})
+
         posid = serializer.validated_data.get('posid')
 
         if posid is None:
@@ -427,21 +432,25 @@ class MerchantViewSet(viewsets.ModelViewSet):
             return Response({})
 
         merchant = pos_device.merchant
+        response_data = MerchantVaultAddressResponseSerializer(merchant).data
+
         logo = merchant.logo_60
-        logo_url = f'{settings.DOMAIN}{logo.url}' if logo else None
-        logo_data = None
         if logo:
-            ext = logo.name.rsplit('.', 1)[-1].lower()
-            mime = 'image/jpeg' if ext in ('jpg', 'jpeg') else f'image/{ext}'
-            logo_data = f'data:{mime};base64,{base64.b64encode(logo.read()).decode()}'
-        return Response({
-            "merchant": {
-                "name": merchant.name,
-                "logo": logo_url,
-                "logo_data": logo_data,
-                "verified": merchant.verified
-            }
-        })
+            try:
+                ext = logo.name.rsplit('.', 1)[-1].lower()
+                if ext in ('jpg', 'jpeg'):
+                    mime = 'image/jpeg'
+                elif ext == 'svg':
+                    mime = 'image/svg+xml'
+                else:
+                    mime = f'image/{ext}'
+                logo.seek(0)
+                if logo.size < 512 * 1024:
+                    response_data['logo_data'] = f'data:{mime};base64,{base64.b64encode(logo.read()).decode()}'
+            except Exception:
+                pass
+
+        return Response(response_data)
 
     @decorators.action(methods=['get'], detail=False)
     def countries(self, request, *args, **kwargs):

--- a/paytacapos/views.py
+++ b/paytacapos/views.py
@@ -383,23 +383,31 @@ class MerchantViewSet(viewsets.ModelViewSet):
         response = { 'index': index }
         return Response(response)
 
-    @swagger_auto_schema(method="post", request_body=MerchantVaultAddressSerializer, response={ 200: MerchantListSerializer })
+    @swagger_auto_schema(method="post", request_body=MerchantVaultAddressSerializer)
     @decorators.action(methods=["post"], detail=False)
     def vault_address(self, request, *args, **kwargs):
         serializer = MerchantVaultAddressSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         address = Address.objects.get(address=serializer.validated_data['address'])
-        try:
-            pos_device = PosDevice.objects.get(
-                wallet_hash=address.wallet.wallet_hash,
-                posid=serializer.validated_data['posid']
-            )
-        except:
+        posid = serializer.validated_data.get('posid')
+
+        qs = PosDevice.objects.filter(wallet_hash=address.wallet.wallet_hash)
+        if posid is not None:
+            qs = qs.filter(posid=posid)
+
+        pos_device = qs.order_by('-id').first()
+        if not pos_device or not pos_device.merchant:
             return Response({})
 
-        serializer = MerchantListSerializer(pos_device.merchant)
-        return Response(serializer.data)
+        merchant = pos_device.merchant
+        logo_url = f'{settings.DOMAIN}{merchant.logo_60.url}' if merchant.logo_60 else None
+        return Response({
+            "merchant": {
+                "name": merchant.name,
+                "logo": logo_url
+            }
+        })
 
     @decorators.action(methods=['get'], detail=False)
     def countries(self, request, *args, **kwargs):


### PR DESCRIPTION
### Summary
- Extract `posid` from `address_path` when not explicitly provided
- Return merchant details (name, logos, location, etc.) in vault_address response
- Include `logo_data` as a base64 data URL for inline rendering
- **Backward compatible**: response retains all `MerchantListSerializer` fields, with `logo_data` added

### Changed Files
- `paytacapos/serializers.py` — `posid` made optional on request; added `MerchantVaultAddressResponseSerializer`
- `paytacapos/views.py` — enriched vault_address response with full merchant details + logo base64 data; added `Address.DoesNotExist` handling; fixed regex to support both `0/` and `1/` address path prefixes