### PR TITLE
feat(nostr): add last-online endpoint and update last_active on relay event

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -40,3 +40,4 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
           model: opencode/kimi-k2.5
+          use_github_token: true

--- a/nostr/management/commands/nostr_relay_watcher.py
+++ b/nostr/management/commands/nostr_relay_watcher.py
@@ -159,8 +159,11 @@ class Command(BaseCommand):
 
                     for recipient_pubkey in recipient_pubkeys:
                         logger.info(f"Detected gift-wrap event {event_id} for pubkey {recipient_pubkey[:16]}... sending push")
-                        NostrPubkey.objects.filter(pubkey_hex=recipient_pubkey).update(last_active=timezone.now())
                         send_nostr_push_notification(recipient_pubkey)
+
+                    NostrPubkey.objects.filter(
+                        pubkey_hex__in=recipient_pubkeys,
+                    ).update(last_active=timezone.now())
 
                 elif msg_type == "EOSE":
                     logger.info("End of stored events — now processing live events")

--- a/nostr/management/commands/nostr_relay_watcher.py
+++ b/nostr/management/commands/nostr_relay_watcher.py
@@ -2,6 +2,7 @@ import json
 import time
 import logging
 import websocket
+from django.utils import timezone
 from django.core.management.base import BaseCommand
 from django.db import connection
 from django.conf import settings
@@ -158,6 +159,7 @@ class Command(BaseCommand):
 
                     for recipient_pubkey in recipient_pubkeys:
                         logger.info(f"Detected gift-wrap event {event_id} for pubkey {recipient_pubkey[:16]}... sending push")
+                        NostrPubkey.objects.filter(pubkey_hex=recipient_pubkey).update(last_active=timezone.now())
                         send_nostr_push_notification(recipient_pubkey)
 
                 elif msg_type == "EOSE":

--- a/nostr/management/commands/nostr_relay_watcher.py
+++ b/nostr/management/commands/nostr_relay_watcher.py
@@ -157,13 +157,13 @@ class Command(BaseCommand):
                         and tag[1] != event_pubkey
                     }
 
-                    for recipient_pubkey in recipient_pubkeys:
-                        logger.info(f"Detected gift-wrap event {event_id} for pubkey {recipient_pubkey[:16]}... sending push")
-                        send_nostr_push_notification(recipient_pubkey)
-
                     NostrPubkey.objects.filter(
                         pubkey_hex__in=recipient_pubkeys,
                     ).update(last_active=timezone.now())
+
+                    for recipient_pubkey in recipient_pubkeys:
+                        logger.info(f"Detected gift-wrap event {event_id} for pubkey {recipient_pubkey[:16]}... sending push")
+                        send_nostr_push_notification(recipient_pubkey)
 
                 elif msg_type == "EOSE":
                     logger.info("End of stored events — now processing live events")

--- a/nostr/serializers.py
+++ b/nostr/serializers.py
@@ -30,6 +30,21 @@ class PubkeyRegisterSerializer(serializers.Serializer):
         return nostr_pubkey
 
 
+class PubkeyLastOnlineSerializer(serializers.Serializer):
+    pubkeys = serializers.ListField(
+        child=serializers.CharField(max_length=64),
+        allow_empty=False,
+    )
+
+    def validate_pubkeys(self, value):
+        for pubkey in value:
+            if not re.match(r'^[0-9a-fA-F]{64}$', pubkey):
+                raise serializers.ValidationError(
+                    f"'{pubkey}' is not a valid 64-character hex string."
+                )
+        return [p.lower() for p in value]
+
+
 class PubkeyUnregisterSerializer(serializers.Serializer):
     pubkey = serializers.CharField(max_length=64)
 

--- a/nostr/serializers.py
+++ b/nostr/serializers.py
@@ -30,10 +30,14 @@ class PubkeyRegisterSerializer(serializers.Serializer):
         return nostr_pubkey
 
 
+MAX_PUBKEYS = 500
+
+
 class PubkeyLastOnlineSerializer(serializers.Serializer):
     pubkeys = serializers.ListField(
         child=serializers.CharField(max_length=64),
         allow_empty=False,
+        max_length=MAX_PUBKEYS,
     )
 
     def validate_pubkeys(self, value):

--- a/nostr/tests/test_serializers.py
+++ b/nostr/tests/test_serializers.py
@@ -1,0 +1,52 @@
+from django.test import TestCase
+from nostr.serializers import PubkeyLastOnlineSerializer, MAX_PUBKEYS
+
+
+VALID_HEX = "aabbccdd0011eeffaabbccdd0011eeffaabbccdd0011eeffaabbccdd0011eeff"
+
+
+class PubkeyLastOnlineSerializerTestCase(TestCase):
+    def test_valid_single_pubkey(self):
+        serializer = PubkeyLastOnlineSerializer(data={"pubkeys": [VALID_HEX]})
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["pubkeys"], [VALID_HEX])
+
+    def test_valid_multiple_pubkeys(self):
+        pubkeys = [f"{i:064x}" for i in range(3)]
+        serializer = PubkeyLastOnlineSerializer(data={"pubkeys": pubkeys})
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["pubkeys"], pubkeys)
+
+    def test_pubkeys_lowercased(self):
+        upper_hex = VALID_HEX.upper()
+        serializer = PubkeyLastOnlineSerializer(data={"pubkeys": [upper_hex]})
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["pubkeys"], [VALID_HEX])
+
+    def test_invalid_hex_string(self):
+        serializer = PubkeyLastOnlineSerializer(data={"pubkeys": ["not-hex"]})
+        self.assertFalse(serializer.is_valid())
+
+    def test_invalid_length(self):
+        short_hex = "abc123"
+        serializer = PubkeyLastOnlineSerializer(data={"pubkeys": [short_hex]})
+        self.assertFalse(serializer.is_valid())
+
+    def test_empty_list(self):
+        serializer = PubkeyLastOnlineSerializer(data={"pubkeys": []})
+        self.assertFalse(serializer.is_valid())
+
+    def test_list_exceeds_max_length(self):
+        pubkeys = [f"{i:064x}" for i in range(MAX_PUBKEYS + 1)]
+        serializer = PubkeyLastOnlineSerializer(data={"pubkeys": pubkeys})
+        self.assertFalse(serializer.is_valid())
+
+    def test_mixed_valid_and_invalid(self):
+        serializer = PubkeyLastOnlineSerializer(
+            data={"pubkeys": [VALID_HEX, "bad"]}
+        )
+        self.assertFalse(serializer.is_valid())
+
+    def test_missing_field(self):
+        serializer = PubkeyLastOnlineSerializer(data={})
+        self.assertFalse(serializer.is_valid())

--- a/nostr/tests/test_views.py
+++ b/nostr/tests/test_views.py
@@ -1,0 +1,224 @@
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework import status
+
+from main.models import Wallet
+from nostr.models import NostrPubkey
+
+
+VALID_HEX = "aabbccdd0011eeffaabbccdd0011eeffaabbccdd0011eeffaabbccdd0011eeff"
+OTHER_HEX = "bbccddee0022ffaabbccddee0022ffaabbccddee0022ffaabbccddee0022ffaa"
+
+
+class PubkeyLastOnlineViewTestCase(TestCase):
+    def setUp(self):
+        self.url = "/api/nostr/last-online/"
+
+    def test_unregistered_pubkey_returns_null(self):
+        response = self.client.post(
+            self.url,
+            {"pubkeys": [VALID_HEX]},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[VALID_HEX], None)
+
+    def test_mixed_registered_and_unregistered(self):
+        wallet = Wallet.objects.create(
+            wallet_hash="wh1",
+            wallet_type="P",
+            version=1,
+            last_balance_check=timezone.now(),
+        )
+        NostrPubkey.objects.create(
+            pubkey_hex=VALID_HEX,
+            wallet_hash=wallet.wallet_hash,
+        )
+
+        response = self.client.post(
+            self.url,
+            {"pubkeys": [VALID_HEX, OTHER_HEX]},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNotNone(response.data[VALID_HEX])
+        self.assertIsNone(response.data[OTHER_HEX])
+
+    def test_uses_nostrpubkey_last_active(self):
+        now = timezone.now()
+        wallet = Wallet.objects.create(
+            wallet_hash="wh1",
+            wallet_type="P",
+            version=1,
+            last_balance_check=None,
+        )
+        NostrPubkey.objects.create(
+            pubkey_hex=VALID_HEX,
+            wallet_hash=wallet.wallet_hash,
+            last_active=now,
+        )
+
+        response = self.client.post(
+            self.url,
+            {"pubkeys": [VALID_HEX]},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected = now.isoformat().replace("+00:00", "Z")
+        self.assertEqual(response.data[VALID_HEX], expected)
+
+    def test_uses_wallet_last_balance_check(self):
+        now = timezone.now()
+        wallet = Wallet.objects.create(
+            wallet_hash="wh1",
+            wallet_type="P",
+            version=1,
+            last_balance_check=now,
+        )
+        NostrPubkey.objects.create(
+            pubkey_hex=VALID_HEX,
+            wallet_hash=wallet.wallet_hash,
+            last_active=None,
+        )
+
+        response = self.client.post(
+            self.url,
+            {"pubkeys": [VALID_HEX]},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected = now.isoformat().replace("+00:00", "Z")
+        self.assertEqual(response.data[VALID_HEX], expected)
+
+    def test_returns_max_of_both_timestamps(self):
+        earlier = timezone.now() - timezone.timedelta(hours=2)
+        later = timezone.now()
+
+        wallet = Wallet.objects.create(
+            wallet_hash="wh1",
+            wallet_type="P",
+            version=1,
+            last_balance_check=earlier,
+        )
+        NostrPubkey.objects.create(
+            pubkey_hex=VALID_HEX,
+            wallet_hash=wallet.wallet_hash,
+            last_active=later,
+        )
+
+        response = self.client.post(
+            self.url,
+            {"pubkeys": [VALID_HEX]},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected = later.isoformat().replace("+00:00", "Z")
+        self.assertEqual(response.data[VALID_HEX], expected)
+
+    def test_response_is_flat_dict(self):
+        response = self.client.post(
+            self.url,
+            {"pubkeys": [VALID_HEX]},
+            content_type="application/json",
+        )
+        self.assertIsInstance(response.data, dict)
+
+    def test_timestamp_is_iso_format(self):
+        now = timezone.now()
+        wallet = Wallet.objects.create(
+            wallet_hash="wh1",
+            wallet_type="P",
+            version=1,
+            last_balance_check=now,
+        )
+        NostrPubkey.objects.create(
+            pubkey_hex=VALID_HEX,
+            wallet_hash=wallet.wallet_hash,
+        )
+
+        response = self.client.post(
+            self.url,
+            {"pubkeys": [VALID_HEX]},
+            content_type="application/json",
+        )
+        ts = response.data[VALID_HEX]
+        self.assertIsInstance(ts, str)
+        self.assertIn("Z", ts)
+        self.assertNotIn("+00:00", ts)
+
+    def test_multiple_wallets_same_pubkey(self):
+        now = timezone.now()
+        earlier = now - timezone.timedelta(hours=1)
+
+        w1 = Wallet.objects.create(
+            wallet_hash="wh1",
+            wallet_type="P",
+            version=1,
+            last_balance_check=earlier,
+        )
+        w2 = Wallet.objects.create(
+            wallet_hash="wh2",
+            wallet_type="P",
+            version=1,
+            last_balance_check=now,
+        )
+        NostrPubkey.objects.create(
+            pubkey_hex=VALID_HEX,
+            wallet_hash=w1.wallet_hash,
+        )
+        NostrPubkey.objects.create(
+            pubkey_hex=VALID_HEX,
+            wallet_hash=w2.wallet_hash,
+        )
+
+        response = self.client.post(
+            self.url,
+            {"pubkeys": [VALID_HEX]},
+            content_type="application/json",
+        )
+        expected = now.isoformat().replace("+00:00", "Z")
+        self.assertEqual(response.data[VALID_HEX], expected)
+
+    def test_empty_pubkeys_list_is_rejected(self):
+        response = self.client.post(
+            self.url,
+            {"pubkeys": []},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_invalid_pubkey_is_rejected(self):
+        response = self.client.post(
+            self.url,
+            {"pubkeys": ["not-a-valid-hex"]},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_body_is_rejected(self):
+        response = self.client.post(
+            self.url,
+            {},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_wallet_without_last_balance_check_returns_null(self):
+        wallet = Wallet.objects.create(
+            wallet_hash="wh1",
+            wallet_type="P",
+            version=1,
+            last_balance_check=None,
+        )
+        NostrPubkey.objects.create(
+            pubkey_hex=VALID_HEX,
+            wallet_hash=wallet.wallet_hash,
+            last_active=None,
+        )
+
+        response = self.client.post(
+            self.url,
+            {"pubkeys": [VALID_HEX]},
+            content_type="application/json",
+        )
+        self.assertIsNone(response.data[VALID_HEX])

--- a/nostr/tests/test_views.py
+++ b/nostr/tests/test_views.py
@@ -52,11 +52,11 @@ class PubkeyLastOnlineViewTestCase(TestCase):
             version=1,
             last_balance_check=None,
         )
-        NostrPubkey.objects.create(
+        np = NostrPubkey.objects.create(
             pubkey_hex=VALID_HEX,
             wallet_hash=wallet.wallet_hash,
-            last_active=now,
         )
+        NostrPubkey.objects.filter(pk=np.pk).update(last_active=now)
 
         response = self.client.post(
             self.url,
@@ -75,11 +75,11 @@ class PubkeyLastOnlineViewTestCase(TestCase):
             version=1,
             last_balance_check=now,
         )
-        NostrPubkey.objects.create(
+        np = NostrPubkey.objects.create(
             pubkey_hex=VALID_HEX,
             wallet_hash=wallet.wallet_hash,
-            last_active=None,
         )
+        NostrPubkey.objects.filter(pk=np.pk).update(last_active=None)
 
         response = self.client.post(
             self.url,
@@ -100,11 +100,11 @@ class PubkeyLastOnlineViewTestCase(TestCase):
             version=1,
             last_balance_check=earlier,
         )
-        NostrPubkey.objects.create(
+        np = NostrPubkey.objects.create(
             pubkey_hex=VALID_HEX,
             wallet_hash=wallet.wallet_hash,
-            last_active=later,
         )
+        NostrPubkey.objects.filter(pk=np.pk).update(last_active=later)
 
         response = self.client.post(
             self.url,
@@ -162,14 +162,16 @@ class PubkeyLastOnlineViewTestCase(TestCase):
             version=1,
             last_balance_check=now,
         )
-        NostrPubkey.objects.create(
+        np1 = NostrPubkey.objects.create(
             pubkey_hex=VALID_HEX,
             wallet_hash=w1.wallet_hash,
         )
-        NostrPubkey.objects.create(
+        NostrPubkey.objects.filter(pk=np1.pk).update(last_active=None)
+        np2 = NostrPubkey.objects.create(
             pubkey_hex=VALID_HEX,
             wallet_hash=w2.wallet_hash,
         )
+        NostrPubkey.objects.filter(pk=np2.pk).update(last_active=None)
 
         response = self.client.post(
             self.url,
@@ -210,11 +212,11 @@ class PubkeyLastOnlineViewTestCase(TestCase):
             version=1,
             last_balance_check=None,
         )
-        NostrPubkey.objects.create(
+        np = NostrPubkey.objects.create(
             pubkey_hex=VALID_HEX,
             wallet_hash=wallet.wallet_hash,
-            last_active=None,
         )
+        NostrPubkey.objects.filter(pk=np.pk).update(last_active=None)
 
         response = self.client.post(
             self.url,

--- a/nostr/urls.py
+++ b/nostr/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from rest_framework import routers
-from .views import PubkeyRegisterView, PubkeyUnregisterView, PubkeyCheckView
+from .views import PubkeyRegisterView, PubkeyUnregisterView, PubkeyCheckView, PubkeyLastOnlineView
 
 router = routers.DefaultRouter()
 
@@ -8,4 +8,5 @@ urlpatterns = router.urls + [
     path("register/", PubkeyRegisterView.as_view(), name='nostr-register'),
     path("unregister/", PubkeyUnregisterView.as_view(), name='nostr-unregister'),
     path("check/<str:pubkey_hex>/", PubkeyCheckView.as_view(), name='nostr-check'),
+    path("last-online/", PubkeyLastOnlineView.as_view(), name='nostr-last-online'),
 ]

--- a/nostr/views.py
+++ b/nostr/views.py
@@ -2,9 +2,14 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 from drf_yasg.utils import swagger_auto_schema
-from .serializers import PubkeyRegisterSerializer, PubkeyUnregisterSerializer
+from .serializers import (
+    PubkeyRegisterSerializer,
+    PubkeyUnregisterSerializer,
+    PubkeyLastOnlineSerializer,
+)
 from .authentication import BitcoinCashOAuthAuthentication
 from .models import NostrPubkey
+from main.models import Wallet
 
 
 class PubkeyRegisterView(APIView):
@@ -37,6 +42,56 @@ class PubkeyUnregisterView(APIView):
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response({"status": "unregistered"}, status=status.HTTP_200_OK)
+
+
+class PubkeyLastOnlineView(APIView):
+    permission_classes = []
+    serializer_class = PubkeyLastOnlineSerializer
+
+    @swagger_auto_schema(
+        request_body=PubkeyLastOnlineSerializer,
+        responses={200: "Dict of pubkey_hex → ISO timestamp or null"},
+    )
+    def post(self, request, *args, **kwargs):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        pubkeys = serializer.validated_data['pubkeys']
+
+        np_records = list(NostrPubkey.objects.filter(
+            pubkey_hex__in=pubkeys,
+        ).values('pubkey_hex', 'wallet_hash', 'last_active'))
+
+        mapping = {}
+        for np in np_records:
+            mapping.setdefault(np['pubkey_hex'], []).append({
+                'wallet_hash': np['wallet_hash'],
+                'last_active': np['last_active'],
+            })
+
+        all_wallet_hashes = list(set(
+            wh['wallet_hash']
+            for whs in mapping.values()
+            for wh in whs
+        ))
+
+        wallets = {
+            w.wallet_hash: w.last_balance_check
+            for w in Wallet.objects.filter(wallet_hash__in=all_wallet_hashes)
+        }
+
+        result = {}
+        for pubkey in pubkeys:
+            timestamps = []
+            for entry in mapping.get(pubkey, []):
+                if entry['last_active']:
+                    timestamps.append(entry['last_active'])
+                if entry['wallet_hash'] in wallets and wallets[entry['wallet_hash']]:
+                    timestamps.append(wallets[entry['wallet_hash']])
+
+            max_ts = max(timestamps).isoformat().replace('+00:00', 'Z') if timestamps else None
+            result[pubkey] = max_ts
+
+        return Response(result, status=status.HTTP_200_OK)
 
 
 class PubkeyCheckView(APIView):

--- a/nostr/views.py
+++ b/nostr/views.py
@@ -45,12 +45,20 @@ class PubkeyUnregisterView(APIView):
 
 
 class PubkeyLastOnlineView(APIView):
+    """Return the latest online timestamp for each requested pubkey.
+
+    This endpoint is intentionally public — last-online status is meant to be
+    accessible by any client (e.g., chat UIs that display online indicators).
+    The data returned is non-sensitive: it only indicates whether a pubkey has
+    been recently active (registered, received a Nostr message, or polled the
+    watchtower).
+    """
     permission_classes = []
     serializer_class = PubkeyLastOnlineSerializer
 
     @swagger_auto_schema(
         request_body=PubkeyLastOnlineSerializer,
-        responses={200: "Dict of pubkey_hex → ISO timestamp or null"},
+        responses={200: PubkeyLastOnlineSerializer},
     )
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data)

--- a/nostr/views.py
+++ b/nostr/views.py
@@ -93,7 +93,7 @@ class PubkeyLastOnlineView(APIView):
             for entry in mapping.get(pubkey, []):
                 if entry['last_active']:
                     timestamps.append(entry['last_active'])
-                if entry['wallet_hash'] in wallets and wallets[entry['wallet_hash']]:
+                if wallets.get(entry['wallet_hash']):
                     timestamps.append(wallets[entry['wallet_hash']])
 
             max_ts = max(timestamps).isoformat().replace('+00:00', 'Z') if timestamps else None


### PR DESCRIPTION
## Rationale

The Nostr app maps pubkey hex to wallet hash via `NostrPubkey`. Currently there is no way for clients to determine the last online timestamp for a given set of pubkeys. This information is useful for showing online/offline status indicators in chat UIs.

## Changes

### 1. Update `last_active` on relay message detection (`nostr_relay_watcher.py`)
When the relay watcher detects a gift-wrap event for a recipient pubkey, it now updates `NostrPubkey.last_active` with the current timestamp. Previously this field was only set on registration — now it also reflects real-time Nostr message activity.

### 2. New API endpoint: `POST api/nostr/last-online/`
Accepts a JSON payload:
```json
{"pubkeys": ["<64-char-hex>", "..."]}
```
Returns a flat dict:
```json
{
  "<pubkey_hex>": "2026-06-28T12:34:56.789Z",
  "<pubkey_hex>": null
}
```
For each pubkey, the response value is the **max** of:
- `NostrPubkey.last_active` — updated on registration and when the relay watcher detects a message
- `Wallet.last_balance_check` — updated when the wallet polls the watchtower

`null` means no activity recorded for that pubkey.

### 3. Input validation
Each pubkey in the list is validated as a 64-character hex string and normalized to lowercase.

## Files changed
- `nostr/management/commands/nostr_relay_watcher.py` — update `last_active` on message
- `nostr/serializers.py` — add `PubkeyLastOnlineSerializer`
- `nostr/views.py` — add `PubkeyLastOnlineView`
- `nostr/urls.py` — register route