### PR TITLE
perf: add covering index and API spec for last-online endpoint

### DIFF
--- a/docs/NOSTR_LAST_ONLINE_API.md
+++ b/docs/NOSTR_LAST_ONLINE_API.md
@@ -1,0 +1,76 @@
+# Nostr Last Online API
+
+## Overview
+
+Returns the latest known online timestamp for one or more Nostr pubkeys. The timestamp is the most recent of:
+
+- `NostrPubkey.last_active` — updated when the pubkey registers or when the relay watcher detects an incoming message for it
+- `Wallet.last_balance_check` — updated when a linked wallet polls the watchtower for its balance
+
+## Endpoint
+
+```
+POST /api/nostr/last-online/
+```
+
+No authentication required.
+
+## Request Body
+
+```json
+{
+  "pubkeys": [
+    "aabbccdd0011eeffaabbccdd0011eeffaabbccdd0011eeffaabbccdd0011eeff",
+    "bbccddee0022ffaabbccddee0022ffaabbccddee0022ffaabbccddee0022ffaa"
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `pubkeys` | array of strings | Yes | 64-character hex-encoded Nostr public keys. Max 500 entries. |
+
+## Response (200 OK)
+
+```json
+{
+  "aabbccdd0011eeffaabbccdd0011eeffaabbccdd0011eeffaabbccdd0011eeff": "2026-06-28T12:34:56.789Z",
+  "bbccddee0022ffaabbccddee0022ffaabbccddee0022ffaabbccddee0022ffaa": null
+}
+```
+
+A flat JSON object mapping each requested pubkey to either:
+- An ISO-8601 UTC timestamp string (e.g. `"2026-06-28T12:34:56.789Z"`) — the latest activity time
+- `null` — no activity recorded for that pubkey
+
+## Response (400 Bad Request)
+
+Returned when the payload is missing, empty, contains invalid hex strings, or exceeds 500 entries.
+
+```json
+{
+  "pubkeys": ["'not-hex' is not a valid 64-character hex string."]
+}
+```
+
+## Client Usage Example
+
+```javascript
+const response = await fetch("https://your-host.com/api/nostr/last-online/", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    pubkeys: ["aabbccdd0011eeffaabbccdd0011eeffaabbccdd0011eeffaabbccdd0011eeff"]
+  })
+});
+
+const data = await response.json();
+const lastOnline = data["aabbccdd0011eeffaabbccdd0011eeffaabbccdd0011eeffaabbccdd0011eeff"];
+// "2026-06-28T12:34:56.789Z" or null
+```
+
+## Notes
+
+- A pubkey with `null` means watchtower has no record of any activity for it.
+- The endpoint is publicly accessible (no auth) so chat UIs can display online indicators without requiring user tokens.
+- If a pubkey maps to multiple wallet hashes, the most recent timestamp across all linked wallets is returned.

--- a/nostr/migrations/0005_add_covering_index.py
+++ b/nostr/migrations/0005_add_covering_index.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nostr', '0004_auto_20260504_0507'),
+    ]
+
+    operations = [
+        migrations.RemoveIndex(
+            model_name='nostrpubkey',
+            name='nostr_nostr_pubkey__046ea9_idx',
+        ),
+        migrations.AddIndex(
+            model_name='nostrpubkey',
+            index=models.Index(
+                fields=['pubkey_hex', 'wallet_hash', 'last_active'],
+                name='nostr_nostr_pubkey__046ea9_idx',
+            ),
+        ),
+    ]

--- a/nostr/models.py
+++ b/nostr/models.py
@@ -13,5 +13,5 @@ class NostrPubkey(models.Model):
 
     class Meta:
         indexes = [
-            models.Index(fields=['pubkey_hex', 'wallet_hash']),
+            models.Index(fields=['pubkey_hex', 'wallet_hash', 'last_active']),
         ]


### PR DESCRIPTION
## Problem

The `NostrPubkey` model index `(pubkey_hex, wallet_hash)` requires Postgres to fetch `last_active` from the table heap after the index lookup, adding an extra I/O round-trip per row. Missing API docs for client app developers.

## Changes

### Covering index
Replaced `(pubkey_hex, wallet_hash)` with `(pubkey_hex, wallet_hash, last_active)` on `NostrPubkey`. The main view query:

```python
NostrPubkey.objects.filter(pubkey_hex__in=…).values("pubkey_hex", "wallet_hash", "last_active")
```

now reads all required columns from the index alone — no heap fetches needed.

### Migration
`nostr/migrations/0005_add_covering_index.py` — removes old index, adds new one (same auto-generated name for in-place swap).

### API spec
`docs/NOSTR_LAST_ONLINE_API.md` — full spec for client app developers covering endpoint URL, request/response format, examples, and notes.