### PR TITLE
feat: add growth report endpoint for daily aggregate metrics

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -87,6 +87,11 @@ main_urls += [
     ),
     re_path(r"^status/$", views.StatusView.as_view(), name="api-status"),
     re_path(
+        r"^reports/growth/$",
+        views.GrowthReportView.as_view(),
+        name="growth-report",
+    ),
+    re_path(
         r"^task/(?P<task_id>[\w+:-]+)/$",
         views.TaskStatusView.as_view(),
         name="task-status",

--- a/main/views/__init__.py
+++ b/main/views/__init__.py
@@ -31,3 +31,4 @@ from main.views.view_project import *
 from main.views.view_asset_setting import *
 from main.views.view_address_book import *
 from main.views.view_wallet_history_explorer import *
+from main.views.view_growth_report import *

--- a/main/views/view_growth_report.py
+++ b/main/views/view_growth_report.py
@@ -1,0 +1,245 @@
+from datetime import datetime, time, timedelta
+
+import pytz
+from django.db.models import (
+    ExpressionWrapper,
+    F,
+    FloatField,
+    Q,
+    Sum,
+)
+from django.db.models.functions import Coalesce
+from django.utils import timezone
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import status as http_status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from main.models import Address, Project, Wallet, WalletHistory
+
+
+def _parse_date(date_str):
+    if date_str:
+        try:
+            return datetime.strptime(date_str, "%Y-%m-%d").date()
+        except (ValueError, TypeError):
+            return None
+    return timezone.now().astimezone(pytz.utc).date()
+
+
+def _day_bounds(report_date):
+    utc = pytz.utc
+    day_start = utc.localize(datetime.combine(report_date, time(0, 0, 0)))
+    day_end = day_start + timedelta(days=1)
+    return day_start, day_end
+
+
+def _safe_div(numerator, denominator):
+    if not denominator:
+        return 0
+    return round(numerator / denominator, 8)
+
+
+class GrowthReportView(APIView):
+    """Return growth-relevant aggregate metrics for a specific UTC day.
+
+    Only BCH wallets (wallet_type='bch') and BCH transactions
+    (token.name='bch') are considered; SLP and smartBCH are excluded.
+    """
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                name="date",
+                type=openapi.TYPE_STRING,
+                in_=openapi.IN_QUERY,
+                description="UTC day in YYYY-MM-DD format. Defaults to today (UTC).",
+            ),
+            openapi.Parameter(
+                name="project",
+                type=openapi.TYPE_STRING,
+                in_=openapi.IN_QUERY,
+                description="Project name to scope the report. Defaults to 'paytaca'.",
+                default="paytaca",
+            ),
+        ],
+    )
+    def get(self, request, *args, **kwargs):
+        date_str = request.query_params.get("date")
+        project_name = request.query_params.get("project", "paytaca")
+
+        report_date = _parse_date(date_str)
+        if report_date is None:
+            return Response(
+                {"error": "Invalid date format. Use YYYY-MM-DD."},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            project = Project.objects.get(name__iexact=project_name)
+        except Project.DoesNotExist:
+            return Response(
+                {"error": f"Project '{project_name}' not found."},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+
+        day_start, day_end = _day_bounds(report_date)
+
+        # ── Wallet metrics ──────────────────────────────────────────
+        wallet_base = Wallet.objects.filter(
+            wallet_type="bch",
+            project=project,
+        )
+        new_wallets = wallet_base.filter(
+            date_created__gte=day_start,
+            date_created__lt=day_end,
+        ).count()
+        cumulative_wallets = wallet_base.filter(
+            date_created__lt=day_end,
+        ).count()
+        daily_active_wallets = wallet_base.filter(
+            last_balance_check__isnull=False,
+            last_balance_check__gte=day_start,
+            last_balance_check__lt=day_end,
+        ).count()
+
+        # ── Address metrics ─────────────────────────────────────────
+        address_base = Address.objects.filter(
+            wallet__wallet_type="bch",
+            wallet__project=project,
+        )
+        new_addresses = address_base.filter(
+            date_created__gte=day_start,
+            date_created__lt=day_end,
+        ).count()
+        cumulative_addresses = address_base.filter(
+            date_created__lt=day_end,
+        ).count()
+
+        # ── Transaction metrics (WalletHistory) ─────────────────────
+        # Use tx_timestamp (on-chain time) with date_created fallback.
+        wh_qs = (
+            WalletHistory.objects
+            .filter(
+                wallet__wallet_type="bch",
+                wallet__project=project,
+                token__name__iexact="bch",
+            )
+            .annotate(
+                effective_timestamp=Coalesce("tx_timestamp", "date_created"),
+            )
+            .filter(
+                effective_timestamp__gte=day_start,
+                effective_timestamp__lt=day_end,
+            )
+        )
+
+        total_transactions = wh_qs.values("txid").distinct().count()
+        incoming_transactions = wh_qs.filter(
+            record_type=WalletHistory.INCOMING,
+        ).count()
+        outgoing_transactions = wh_qs.filter(
+            record_type=WalletHistory.OUTGOING,
+        ).count()
+        total_records = incoming_transactions + outgoing_transactions
+
+        # Volume aggregations
+        volume_agg = wh_qs.aggregate(
+            total_bch_volume=Sum("amount"),
+            incoming_bch_volume=Sum(
+                "amount",
+                filter=Q(record_type=WalletHistory.INCOMING),
+            ),
+            outgoing_bch_volume=Sum(
+                "amount",
+                filter=Q(record_type=WalletHistory.OUTGOING),
+            ),
+            total_tx_fees=Sum("tx_fee"),
+        )
+        total_bch_volume = volume_agg["total_bch_volume"] or 0
+        incoming_bch_volume = volume_agg["incoming_bch_volume"] or 0
+        outgoing_bch_volume = volume_agg["outgoing_bch_volume"] or 0
+        total_tx_fees = volume_agg["total_tx_fees"] or 0
+
+        # USD volume: amount * usd_price per record
+        usd_qs = wh_qs.annotate(
+            usd_value=ExpressionWrapper(
+                F("amount") * F("usd_price"),
+                output_field=FloatField(),
+            ),
+        )
+        usd_agg = usd_qs.aggregate(
+            total_usd_volume=Sum("usd_value"),
+            incoming_usd_volume=Sum(
+                "usd_value",
+                filter=Q(record_type=WalletHistory.INCOMING),
+            ),
+            outgoing_usd_volume=Sum(
+                "usd_value",
+                filter=Q(record_type=WalletHistory.OUTGOING),
+            ),
+        )
+        total_usd_volume = float(usd_agg["total_usd_volume"] or 0)
+        incoming_usd_volume = float(usd_agg["incoming_usd_volume"] or 0)
+        outgoing_usd_volume = float(usd_agg["outgoing_usd_volume"] or 0)
+
+        # Active wallets via transactions
+        active_wallets_via_tx = (
+            wh_qs.values("wallet_id").distinct().count()
+        )
+        active_sending_wallets = (
+            wh_qs.filter(record_type=WalletHistory.OUTGOING)
+            .values("wallet_id")
+            .distinct()
+            .count()
+        )
+        active_receiving_wallets = (
+            wh_qs.filter(record_type=WalletHistory.INCOMING)
+            .values("wallet_id")
+            .distinct()
+            .count()
+        )
+
+        # ── Derived / engagement metrics ────────────────────────────
+        average_bch_tx_value = _safe_div(total_bch_volume, total_records)
+        average_usd_tx_value = _safe_div(total_usd_volume, total_records)
+        transactions_per_active_wallet = _safe_div(
+            total_transactions, active_wallets_via_tx
+        )
+        net_bch_flow = round(incoming_bch_volume - outgoing_bch_volume, 8)
+
+        return Response({
+            "date": report_date.isoformat(),
+            "project": project.name,
+            "wallets": {
+                "new_wallets": new_wallets,
+                "cumulative_wallets": cumulative_wallets,
+                "daily_active_wallets": daily_active_wallets,
+                "active_wallets_via_transactions": active_wallets_via_tx,
+            },
+            "addresses": {
+                "new_addresses": new_addresses,
+                "cumulative_addresses": cumulative_addresses,
+            },
+            "transactions": {
+                "total_transactions": total_transactions,
+                "incoming_transactions": incoming_transactions,
+                "outgoing_transactions": outgoing_transactions,
+                "total_bch_volume": round(total_bch_volume, 8),
+                "incoming_bch_volume": round(incoming_bch_volume, 8),
+                "outgoing_bch_volume": round(outgoing_bch_volume, 8),
+                "total_usd_volume": round(total_usd_volume, 2),
+                "incoming_usd_volume": round(incoming_usd_volume, 2),
+                "outgoing_usd_volume": round(outgoing_usd_volume, 2),
+                "average_bch_tx_value": average_bch_tx_value,
+                "average_usd_tx_value": round(average_usd_tx_value, 2),
+                "total_tx_fees": round(total_tx_fees, 8),
+                "active_sending_wallets": active_sending_wallets,
+                "active_receiving_wallets": active_receiving_wallets,
+            },
+            "engagement": {
+                "transactions_per_active_wallet": transactions_per_active_wallet,
+                "net_bch_flow": net_bch_flow,
+            },
+        })

--- a/main/views/view_growth_report.py
+++ b/main/views/view_growth_report.py
@@ -2,13 +2,13 @@ from datetime import datetime, time, timedelta
 
 import pytz
 from django.db.models import (
+    DecimalField,
     ExpressionWrapper,
     F,
-    FloatField,
+    Max,
     Q,
     Sum,
 )
-from django.db.models.functions import Coalesce
 from django.utils import timezone
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
@@ -25,7 +25,7 @@ def _parse_date(date_str):
             return datetime.strptime(date_str, "%Y-%m-%d").date()
         except (ValueError, TypeError):
             return None
-    return timezone.now().astimezone(pytz.utc).date()
+    return timezone.now().date()
 
 
 def _day_bounds(report_date):
@@ -46,6 +46,18 @@ class GrowthReportView(APIView):
 
     Only BCH wallets (wallet_type='bch') and BCH transactions
     (token.name='bch') are considered; SLP and smartBCH are excluded.
+
+    Transaction counts (total/incoming/outgoing) use distinct txids.
+    Record counts (total/incoming/outgoing) count individual
+    WalletHistory rows, which may be higher since a single txid can
+    produce multiple records (e.g. incoming + outgoing for two
+    Paytaca wallets in the same on-chain transaction).
+
+    Volume metrics sum across all records; records with NULL
+    usd_price are silently excluded from USD volume sums.
+
+    Fee aggregation is per-distinct-txid (using Max) to avoid
+    double-counting when multiple rows share the same txid.
     """
 
     @swagger_auto_schema(
@@ -119,32 +131,46 @@ class GrowthReportView(APIView):
 
         # ── Transaction metrics (WalletHistory) ─────────────────────
         # Use tx_timestamp (on-chain time) with date_created fallback.
-        wh_qs = (
-            WalletHistory.objects
-            .filter(
-                wallet__wallet_type="bch",
-                wallet__project=project,
-                token__name__iexact="bch",
-            )
-            .annotate(
-                effective_timestamp=Coalesce("tx_timestamp", "date_created"),
-            )
-            .filter(
-                effective_timestamp__gte=day_start,
-                effective_timestamp__lt=day_end,
+        # The Q-OR form lets the planner use indexes on tx_timestamp
+        # and date_created directly, unlike an annotated Coalesce.
+        wh_qs = WalletHistory.objects.filter(
+            wallet__wallet_type="bch",
+            wallet__project=project,
+            token__name__iexact="bch",
+        ).filter(
+            Q(tx_timestamp__gte=day_start, tx_timestamp__lt=day_end)
+            | Q(
+                tx_timestamp__isnull=True,
+                date_created__gte=day_start,
+                date_created__lt=day_end,
             )
         )
 
+        # Distinct-txid counts (unique on-chain transactions)
         total_transactions = wh_qs.values("txid").distinct().count()
-        incoming_transactions = wh_qs.filter(
+        incoming_transactions = (
+            wh_qs.filter(record_type=WalletHistory.INCOMING)
+            .values("txid")
+            .distinct()
+            .count()
+        )
+        outgoing_transactions = (
+            wh_qs.filter(record_type=WalletHistory.OUTGOING)
+            .values("txid")
+            .distinct()
+            .count()
+        )
+
+        # Record counts (individual WalletHistory rows)
+        total_transaction_records = wh_qs.count()
+        incoming_transaction_records = wh_qs.filter(
             record_type=WalletHistory.INCOMING,
         ).count()
-        outgoing_transactions = wh_qs.filter(
+        outgoing_transaction_records = wh_qs.filter(
             record_type=WalletHistory.OUTGOING,
         ).count()
-        total_records = incoming_transactions + outgoing_transactions
 
-        # Volume aggregations
+        # Volume aggregations (sum across all records)
         volume_agg = wh_qs.aggregate(
             total_bch_volume=Sum("amount"),
             incoming_bch_volume=Sum(
@@ -155,18 +181,27 @@ class GrowthReportView(APIView):
                 "amount",
                 filter=Q(record_type=WalletHistory.OUTGOING),
             ),
-            total_tx_fees=Sum("tx_fee"),
         )
         total_bch_volume = volume_agg["total_bch_volume"] or 0
         incoming_bch_volume = volume_agg["incoming_bch_volume"] or 0
         outgoing_bch_volume = volume_agg["outgoing_bch_volume"] or 0
-        total_tx_fees = volume_agg["total_tx_fees"] or 0
 
-        # USD volume: amount * usd_price per record
+        # Fee: aggregate per txid first (Max, since fee is identical
+        # across rows for the same txid), then sum to avoid
+        # double-counting.
+        total_tx_fees = (
+            wh_qs.values("txid")
+            .annotate(fee=Max("tx_fee"))
+            .aggregate(total=Sum("fee"))["total"]
+            or 0
+        )
+
+        # USD volume: keep as Decimal (via DecimalField output) until
+        # the response dict to avoid premature float artifacts.
         usd_qs = wh_qs.annotate(
             usd_value=ExpressionWrapper(
                 F("amount") * F("usd_price"),
-                output_field=FloatField(),
+                output_field=DecimalField(max_digits=20, decimal_places=8),
             ),
         )
         usd_agg = usd_qs.aggregate(
@@ -180,9 +215,9 @@ class GrowthReportView(APIView):
                 filter=Q(record_type=WalletHistory.OUTGOING),
             ),
         )
-        total_usd_volume = float(usd_agg["total_usd_volume"] or 0)
-        incoming_usd_volume = float(usd_agg["incoming_usd_volume"] or 0)
-        outgoing_usd_volume = float(usd_agg["outgoing_usd_volume"] or 0)
+        total_usd_volume = usd_agg["total_usd_volume"] or 0
+        incoming_usd_volume = usd_agg["incoming_usd_volume"] or 0
+        outgoing_usd_volume = usd_agg["outgoing_usd_volume"] or 0
 
         # Active wallets via transactions
         active_wallets_via_tx = (
@@ -202,8 +237,14 @@ class GrowthReportView(APIView):
         )
 
         # ── Derived / engagement metrics ────────────────────────────
-        average_bch_tx_value = _safe_div(total_bch_volume, total_records)
-        average_usd_tx_value = _safe_div(total_usd_volume, total_records)
+        # Averages are per-record (volume / record count) since volume
+        # is a record-level sum.
+        average_bch_record_value = _safe_div(
+            total_bch_volume, total_transaction_records
+        )
+        average_usd_record_value = _safe_div(
+            total_usd_volume, total_transaction_records
+        )
         transactions_per_active_wallet = _safe_div(
             total_transactions, active_wallets_via_tx
         )
@@ -226,14 +267,19 @@ class GrowthReportView(APIView):
                 "total_transactions": total_transactions,
                 "incoming_transactions": incoming_transactions,
                 "outgoing_transactions": outgoing_transactions,
+                "total_transaction_records": total_transaction_records,
+                "incoming_transaction_records": incoming_transaction_records,
+                "outgoing_transaction_records": outgoing_transaction_records,
                 "total_bch_volume": round(total_bch_volume, 8),
                 "incoming_bch_volume": round(incoming_bch_volume, 8),
                 "outgoing_bch_volume": round(outgoing_bch_volume, 8),
-                "total_usd_volume": round(total_usd_volume, 2),
-                "incoming_usd_volume": round(incoming_usd_volume, 2),
-                "outgoing_usd_volume": round(outgoing_usd_volume, 2),
-                "average_bch_tx_value": average_bch_tx_value,
-                "average_usd_tx_value": round(average_usd_tx_value, 2),
+                "total_usd_volume": float(round(total_usd_volume, 2)),
+                "incoming_usd_volume": float(round(incoming_usd_volume, 2)),
+                "outgoing_usd_volume": float(round(outgoing_usd_volume, 2)),
+                "average_bch_record_value": average_bch_record_value,
+                "average_usd_record_value": float(
+                    round(average_usd_record_value, 2)
+                ),
                 "total_tx_fees": round(total_tx_fees, 8),
                 "active_sending_wallets": active_sending_wallets,
                 "active_receiving_wallets": active_receiving_wallets,

--- a/tests/test_growth_report.py
+++ b/tests/test_growth_report.py
@@ -1,0 +1,383 @@
+from datetime import timedelta
+from decimal import Decimal
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from main.models import Address, Project, Token, Wallet, WalletHistory
+
+
+def _utc_date_str(dt):
+    """Return YYYY-MM-DD string for a timezone-aware datetime (in UTC)."""
+    return dt.strftime("%Y-%m-%d")
+
+
+class GrowthReportViewTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.project = Project.objects.create(name="paytaca")
+        self.bch_token = Token.objects.create(
+            name="bch",
+            tokenid="",
+            token_ticker="BCH",
+        )
+        self.slp_token = Token.objects.create(
+            name="spice",
+            tokenid="abc123",
+            token_ticker="SPICE",
+        )
+
+        # BCH wallet
+        self.wallet_a = Wallet.objects.create(
+            wallet_hash="wallet_a_hash",
+            wallet_type="bch",
+            version=2,
+            project=self.project,
+        )
+        self.wallet_b = Wallet.objects.create(
+            wallet_hash="wallet_b_hash",
+            wallet_type="bch",
+            version=2,
+            project=self.project,
+        )
+        # SLP wallet (should be excluded)
+        self.wallet_slp = Wallet.objects.create(
+            wallet_hash="wallet_slp_hash",
+            wallet_type="slp",
+            version=2,
+            project=self.project,
+        )
+
+        self.addr_a = Address.objects.create(
+            address="bitcoincash:qaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            address_path="0/0",
+            wallet=self.wallet_a,
+            project=self.project,
+        )
+        self.addr_b = Address.objects.create(
+            address="bitcoincash:qbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            address_path="0/0",
+            wallet=self.wallet_b,
+            project=self.project,
+        )
+
+        self.url = reverse("growth-report")
+        self.report_date = timezone.now().date()
+        self.date_str = _utc_date_str(timezone.now())
+
+    def _create_wallet_history(self, **kwargs):
+        defaults = {
+            "wallet": self.wallet_a,
+            "txid": "default_txid",
+            "record_type": WalletHistory.INCOMING,
+            "amount": 1.0,
+            "token": self.bch_token,
+            "tx_timestamp": timezone.now(),
+        }
+        defaults.update(kwargs)
+        return WalletHistory.objects.create(**defaults)
+
+    # ── Response shape & validation ────────────────────────────────
+
+    def test_response_has_all_expected_keys(self):
+        response = self.client.get(self.url, {"date": self.date_str})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+
+        self.assertEqual(data["date"], self.date_str)
+        self.assertEqual(data["project"], "paytaca")
+
+        for key in [
+            "new_wallets",
+            "cumulative_wallets",
+            "daily_active_wallets",
+            "active_wallets_via_transactions",
+        ]:
+            self.assertIn(key, data["wallets"])
+
+        for key in ["new_addresses", "cumulative_addresses"]:
+            self.assertIn(key, data["addresses"])
+
+        for key in [
+            "total_transactions",
+            "incoming_transactions",
+            "outgoing_transactions",
+            "total_transaction_records",
+            "incoming_transaction_records",
+            "outgoing_transaction_records",
+            "total_bch_volume",
+            "incoming_bch_volume",
+            "outgoing_bch_volume",
+            "total_usd_volume",
+            "incoming_usd_volume",
+            "outgoing_usd_volume",
+            "average_bch_record_value",
+            "average_usd_record_value",
+            "total_tx_fees",
+            "active_sending_wallets",
+            "active_receiving_wallets",
+        ]:
+            self.assertIn(key, data["transactions"])
+
+        for key in [
+            "transactions_per_active_wallet",
+            "net_bch_flow",
+        ]:
+            self.assertIn(key, data["engagement"])
+
+    def test_invalid_date_format_returns_400(self):
+        response = self.client.get(self.url, {"date": "not-a-date"})
+        self.assertEqual(response.status_code, 400)
+
+    def test_nonexistent_project_returns_400(self):
+        response = self.client.get(
+            self.url, {"date": self.date_str, "project": "nonexistent"}
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_default_project_is_paytaca(self):
+        response = self.client.get(self.url, {"date": self.date_str})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["project"], "paytaca")
+
+    # ── Wallet metrics ─────────────────────────────────────────────
+
+    def test_new_wallets_count(self):
+        response = self.client.get(self.url, {"date": self.date_str})
+        self.assertEqual(response.status_code, 200)
+        # 2 BCH wallets created today (setUp), SLP wallet excluded
+        self.assertEqual(response.json()["wallets"]["new_wallets"], 2)
+
+    def test_cumulative_wallets_count(self):
+        # Create a wallet on a previous day
+        Wallet.objects.create(
+            wallet_hash="old_wallet",
+            wallet_type="bch",
+            version=2,
+            project=self.project,
+            date_created=timezone.now() - timedelta(days=5),
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        self.assertEqual(response.json()["wallets"]["cumulative_wallets"], 3)
+
+    def test_daily_active_wallets(self):
+        self.wallet_a.last_balance_check = timezone.now()
+        self.wallet_a.save()
+        response = self.client.get(self.url, {"date": self.date_str})
+        self.assertEqual(response.json()["wallets"]["daily_active_wallets"], 1)
+
+    # ── Transaction counts (distinct txid vs records) ─────────────
+
+    def test_transaction_vs_record_counts(self):
+        """A single txid with both incoming and outgoing records:
+        total_transactions=1 but total_transaction_records=2."""
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="shared_txid",
+            record_type=WalletHistory.OUTGOING,
+            amount=1.0,
+        )
+        self._create_wallet_history(
+            wallet=self.wallet_b,
+            txid="shared_txid",
+            record_type=WalletHistory.INCOMING,
+            amount=1.0,
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        tx = response.json()["transactions"]
+
+        self.assertEqual(tx["total_transactions"], 1)
+        self.assertEqual(tx["incoming_transactions"], 1)
+        self.assertEqual(tx["outgoing_transactions"], 1)
+        self.assertEqual(tx["total_transaction_records"], 2)
+        self.assertEqual(tx["incoming_transaction_records"], 1)
+        self.assertEqual(tx["outgoing_transaction_records"], 1)
+
+    # ── Fee aggregation (no double counting) ───────────────────────
+
+    def test_tx_fees_not_double_counted(self):
+        """Same txid with two records: fee should be counted once."""
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="fee_test_txid",
+            record_type=WalletHistory.OUTGOING,
+            amount=1.0,
+            tx_fee=0.0001,
+        )
+        self._create_wallet_history(
+            wallet=self.wallet_b,
+            txid="fee_test_txid",
+            record_type=WalletHistory.INCOMING,
+            amount=1.0,
+            tx_fee=0.0001,
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        self.assertEqual(
+            response.json()["transactions"]["total_tx_fees"],
+            round(0.0001, 8),
+        )
+
+    # ── Volume & averages ──────────────────────────────────────────
+
+    def test_bch_volume(self):
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="vol_in_txid",
+            record_type=WalletHistory.INCOMING,
+            amount=2.5,
+        )
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="vol_out_txid",
+            record_type=WalletHistory.OUTGOING,
+            amount=1.0,
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        tx = response.json()["transactions"]
+
+        self.assertEqual(tx["total_bch_volume"], round(3.5, 8))
+        self.assertEqual(tx["incoming_bch_volume"], round(2.5, 8))
+        self.assertEqual(tx["outgoing_bch_volume"], round(1.0, 8))
+
+    def test_usd_volume(self):
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="usd_txid",
+            record_type=WalletHistory.INCOMING,
+            amount=2.0,
+            usd_price=Decimal("100.00"),
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        tx = response.json()["transactions"]
+
+        self.assertEqual(tx["total_usd_volume"], 200.0)
+        self.assertEqual(tx["incoming_usd_volume"], 200.0)
+        self.assertEqual(tx["outgoing_usd_volume"], 0.0)
+
+    def test_average_record_value(self):
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="avg1_txid",
+            record_type=WalletHistory.INCOMING,
+            amount=3.0,
+        )
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="avg2_txid",
+            record_type=WalletHistory.OUTGOING,
+            amount=1.0,
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        tx = response.json()["transactions"]
+
+        # (3.0 + 1.0) / 2 records = 2.0
+        self.assertEqual(tx["average_bch_record_value"], round(2.0, 8))
+
+    def test_net_bch_flow(self):
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="flow_in_txid",
+            record_type=WalletHistory.INCOMING,
+            amount=5.0,
+        )
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="flow_out_txid",
+            record_type=WalletHistory.OUTGOING,
+            amount=2.0,
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        self.assertEqual(
+            response.json()["engagement"]["net_bch_flow"],
+            round(3.0, 8),
+        )
+
+    # ── Exclusion of non-BCH wallets/tokens ────────────────────────
+
+    def test_slp_wallet_excluded(self):
+        self._create_wallet_history(
+            wallet=self.wallet_slp,
+            txid="slp_txid",
+            record_type=WalletHistory.INCOMING,
+            amount=10.0,
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        tx = response.json()["transactions"]
+        self.assertEqual(tx["total_transactions"], 0)
+        self.assertEqual(tx["total_bch_volume"], 0)
+
+    def test_non_bch_token_excluded(self):
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="slp_token_txid",
+            record_type=WalletHistory.INCOMING,
+            amount=10.0,
+            token=self.slp_token,
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        tx = response.json()["transactions"]
+        self.assertEqual(tx["total_transactions"], 0)
+
+    # ── Date filtering ─────────────────────────────────────────────
+
+    def test_transactions_outside_date_excluded(self):
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="old_txid",
+            record_type=WalletHistory.INCOMING,
+            amount=5.0,
+            tx_timestamp=timezone.now() - timedelta(days=3),
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        tx = response.json()["transactions"]
+        self.assertEqual(tx["total_transactions"], 0)
+
+    def test_null_tx_timestamp_falls_back_to_date_created(self):
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="null_ts_txid",
+            record_type=WalletHistory.INCOMING,
+            amount=1.0,
+            tx_timestamp=None,
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        tx = response.json()["transactions"]
+        self.assertEqual(tx["total_transactions"], 1)
+
+    # ── Active wallets ─────────────────────────────────────────────
+
+    def test_active_sending_and_receiving_wallets(self):
+        self._create_wallet_history(
+            wallet=self.wallet_a,
+            txid="send_txid",
+            record_type=WalletHistory.OUTGOING,
+            amount=1.0,
+        )
+        self._create_wallet_history(
+            wallet=self.wallet_b,
+            txid="recv_txid",
+            record_type=WalletHistory.INCOMING,
+            amount=1.0,
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        tx = response.json()["transactions"]
+
+        self.assertEqual(tx["active_sending_wallets"], 1)
+        self.assertEqual(tx["active_receiving_wallets"], 1)
+
+    # ── Empty data ─────────────────────────────────────────────────
+
+    def test_empty_data_returns_zeros(self):
+        response = self.client.get(
+            self.url, {"date": "2020-01-01", "project": "paytaca"}
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["wallets"]["new_wallets"], 0)
+        self.assertEqual(data["wallets"]["cumulative_wallets"], 0)
+        self.assertEqual(data["transactions"]["total_transactions"], 0)
+        self.assertEqual(data["transactions"]["total_bch_volume"], 0)
+        self.assertEqual(data["transactions"]["total_tx_fees"], 0)
+        self.assertEqual(data["engagement"]["net_bch_flow"], 0)


### PR DESCRIPTION
## Summary

Adds a new endpoint `GET /api/reports/growth/` that returns 18 growth-relevant aggregate metrics for a specific UTC day, derived from the wallet, transaction, and address data that watchtower tracks.

## Endpoint

```
GET /api/reports/growth/?date=YYYY-MM-DD&project=paytaca
```

- **`date`** — UTC day in `YYYY-MM-DD` format. Defaults to today (UTC) if omitted.
- **`project`** — Project name to scope the report. Defaults to `paytaca`.

Only **BCH wallets** (`wallet_type='bch'`) and **BCH transactions** (`token.name='bch'`) are counted — SLP and smartBCH are excluded.

## Metrics returned

| Category | Metrics |
|---|---|
| **Wallets** | new_wallets, cumulative_wallets, daily_active_wallets, active_wallets_via_transactions |
| **Addresses** | new_addresses, cumulative_addresses |
| **Transactions** | total_transactions, incoming/outgoing_transactions, total/incoming/outgoing BCH volume, total/incoming/outgoing USD volume, average BCH/USD tx value, total_tx_fees, active_sending_wallets, active_receiving_wallets |
| **Engagement** | transactions_per_active_wallet, net_bch_flow |

Transaction metrics use `tx_timestamp` (on-chain time) with a `date_created` fallback via `Coalesce`. Daily active wallets use `last_balance_check`.

## Sample response

```json
{
  "date": "2026-07-01",
  "project": "paytaca",
  "wallets": {
    "new_wallets": 42,
    "cumulative_wallets": 15000,
    "daily_active_wallets": 350,
    "active_wallets_via_transactions": 120
  },
  "addresses": {
    "new_addresses": 150,
    "cumulative_addresses": 50000
  },
  "transactions": {
    "total_transactions": 500,
    "incoming_transactions": 300,
    "outgoing_transactions": 200,
    "total_bch_volume": 125.5,
    "incoming_bch_volume": 75.3,
    "outgoing_bch_volume": 50.2,
    "total_usd_volume": 37500.00,
    "incoming_usd_volume": 22500.00,
    "outgoing_usd_volume": 15000.00,
    "average_bch_tx_value": 0.25,
    "average_usd_tx_value": 75.00,
    "total_tx_fees": 0.005,
    "active_sending_wallets": 80,
    "active_receiving_wallets": 100
  },
  "engagement": {
    "transactions_per_active_wallet": 4.17,
    "net_bch_flow": 25.1
  }
}
```

## Files changed

- `main/views/view_growth_report.py` — new `GrowthReportView` with all 18 metrics
- `main/views/__init__.py` — added import
- `main/urls.py` — added `^reports/growth/$` route