### PR TITLE
feat: add chat typing status over nostr websocket

### DIFF
--- a/docs/NOSTR_TYPING_STATUS_FRONTEND_GUIDE.md
+++ b/docs/NOSTR_TYPING_STATUS_FRONTEND_GUIDE.md
@@ -1,0 +1,179 @@
+# Nostr Typing Status — Frontend Integration Guide
+
+## Overview
+
+Typing indicators are delivered over the same WebSocket connection used for
+last-active (green dot) status. No new endpoint or REST call is needed.
+
+| Resource | URL | Purpose |
+|----------|-----|---------|
+| **WebSocket** | `wss://watchtower.cash/ws/nostr/updates/<wallet_hash>/` | Send typing signals; receive real-time typing events from contacts |
+
+The server derives the sender's identity from the authenticated WebSocket
+connection — the client never sends its own pubkey, only the `room_id` and
+`recipients`.
+
+---
+
+## 1. Send a Typing Signal
+
+When the user starts typing in a chat room, send a `typing` message over the
+existing WebSocket connection:
+
+```javascript
+function sendTyping(ws, roomId, recipientPubkeys) {
+  if (ws.readyState !== WebSocket.OPEN) return;
+
+  ws.send(JSON.stringify({
+    type: 'typing',
+    room_id: roomId,
+    recipients: recipientPubkeys, // e.g. ["b_pubkey_hex", "c_pubkey_hex"]
+  }));
+}
+```
+
+### Throttling
+
+The server applies a **3-second throttle** per sender pubkey per room. If a
+typing signal arrives within the throttle window, the server silently drops it
+(no error, no close). The client should also throttle locally to avoid
+sending redundant messages:
+
+```javascript
+let lastTypingSent = 0;
+const TYPING_THROTTLE_MS = 3000; // 3s — must match server throttle
+
+function onTextInput(ws, roomId, recipientPubkeys) {
+  const now = Date.now();
+  if (now - lastTypingSent < TYPING_THROTTLE_MS) return;
+  lastTypingSent = now;
+  sendTyping(ws, roomId, recipientPubkeys);
+}
+```
+
+### Message Format
+
+```json
+{
+  "type": "typing",
+  "room_id": "<room_id>",
+  "recipients": ["<64-char hex pubkey>", ...]
+}
+```
+
+### Constraints
+
+- `room_id` is required and must be a string.
+- `recipients` is required, must be a non-empty list of 64-character hex
+  pubkeys, max **500** entries.
+- If either field is missing/invalid, the server closes the WebSocket with
+  code `4001`.
+- The sender's pubkey is derived from the authenticated connection — do not
+  include it in the message.
+
+---
+
+## 2. Receive a Typing Event
+
+When a contact starts typing, the server pushes a `typing` event to your
+WebSocket:
+
+```javascript
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+
+  if (msg.type === 'typing') {
+    handleTyping(msg.pubkey_hex, msg.room_id);
+  } else if (msg.type === 'last_active') {
+    handleLastActive(msg.pubkey_hex, msg.timestamp);
+  }
+};
+```
+
+### Event Shape
+
+```json
+{
+  "type": "typing",
+  "pubkey_hex": "<sender_pubkey_hex>",
+  "room_id": "<room_id>"
+}
+```
+
+### Auto-Hide Logic
+
+Show the typing indicator when an event arrives, then auto-hide it after
+**5 seconds** if no new typing event is received for the same pubkey + room:
+
+```javascript
+const typingTimers = new Map(); // `${pubkey}:${room_id}` -> timeoutId
+
+function handleTyping(pubkeyHex, roomId) {
+  const key = `${pubkeyHex}:${roomId}`;
+  showTypingIndicator(pubkeyHex, roomId);
+
+  if (typingTimers.has(key)) {
+    clearTimeout(typingTimers.get(key));
+  }
+
+  const timeoutId = setTimeout(() => {
+    hideTypingIndicator(pubkeyHex, roomId);
+    typingTimers.delete(key);
+  }, 5000); // 5s
+
+  typingTimers.set(key, timeoutId);
+}
+```
+
+---
+
+## 3. Privacy
+
+Typing indicators respect the existing `show_active_status` privacy toggle:
+
+- If the **sender** has `show_active_status=False`, their typing signals are
+  never broadcast to anyone.
+- If the **recipient** has `show_active_status=False`, they will not receive
+  typing events from anyone.
+
+This is the same mutual-consent model used by last-active/green-dot status.
+No additional privacy controls are needed.
+
+---
+
+## 4. Recommended Frontend Flow
+
+1. **User opens a chat room**
+   - WebSocket is already connected (for heartbeats / last-active)
+   - On text input, call `sendTyping()` at most every 3 seconds
+
+2. **You receive a WS `typing` event**
+   - Show "X is typing..." in the matching room
+   - Start/reset a 5-second auto-hide timer
+
+3. **User stops typing or leaves the room**
+   - No explicit "stop typing" message is needed
+   - The 5-second timer on the recipient side will auto-hide the indicator
+
+4. **User sends a message**
+   - Continue sending heartbeats as normal
+   - Call `touchAfterSend()` as before — the recipient's typing indicator
+     is unrelated to the last-active push
+
+---
+
+## 5. Error Handling
+
+| Scenario | Server behavior |
+|----------|----------------|
+| Missing `room_id` or `recipients` | Closes WebSocket with code `4001` |
+| Invalid recipient pubkey (not 64-char hex) | Closes WebSocket with code `4001` |
+| More than 500 recipients | Closes WebSocket with code `4001` |
+| Unrecognized message type | Closes WebSocket with code `4001` |
+| Sender has `show_active_status=False` | Silently dropped (no broadcast) |
+| Recipient has `show_active_status=False` | Silently dropped (no forward) |
+| Within 3s throttle window | Silently dropped (no broadcast) |
+| Recipient not registered on watchtower | Silently skipped (no WS push) |
+
+If the WebSocket is closed with code `4001`, the client should reconnect with
+backoff and re-send only valid messages.

--- a/main/utils/cache.py
+++ b/main/utils/cache.py
@@ -440,12 +440,3 @@ def set_typing_throttle(pubkey_hex, room_id):
     cache_key = f'typing:{pubkey_hex}:{room_id}'
     was_set = cache.set(cache_key, b'1', ex=TYPING_THROTTLE_TTL, nx=True)
     return bool(was_set)
-
-
-def is_typing_throttled(pubkey_hex, room_id):
-    """Return True if a typing throttle key currently exists."""
-    if not pubkey_hex or not room_id:
-        return False
-    cache = settings.REDISKV
-    cache_key = f'typing:{pubkey_hex}:{room_id}'
-    return cache.exists(cache_key) == 1

--- a/main/utils/cache.py
+++ b/main/utils/cache.py
@@ -423,3 +423,29 @@ def clear_last_active(pubkey_hex):
     cache = settings.REDISKV
     cache_key = f'last_active:{pubkey_hex}'
     cache.delete(cache_key)
+
+
+TYPING_THROTTLE_TTL = 3  # seconds
+
+
+def set_typing_throttle(pubkey_hex, room_id):
+    """Set a short-lived throttle key so repeated typing bursts are coalesced.
+
+    Returns True if the key was newly set (i.e. this call was not throttled),
+    False if a throttle key already existed (caller should skip the broadcast).
+    """
+    if not pubkey_hex or not room_id:
+        return True
+    cache = settings.REDISKV
+    cache_key = f'typing:{pubkey_hex}:{room_id}'
+    was_set = cache.set(cache_key, b'1', ex=TYPING_THROTTLE_TTL, nx=True)
+    return bool(was_set)
+
+
+def is_typing_throttled(pubkey_hex, room_id):
+    """Return True if a typing throttle key currently exists."""
+    if not pubkey_hex or not room_id:
+        return False
+    cache = settings.REDISKV
+    cache_key = f'typing:{pubkey_hex}:{room_id}'
+    return cache.exists(cache_key) == 1

--- a/nostr/consumers.py
+++ b/nostr/consumers.py
@@ -17,8 +17,12 @@ class NostrUpdatesConsumer(JsonWebsocketConsumer):
     When a message is received from a sender, each recipient gets a
     ``last_active`` event pushed to their WebSocket.
 
-    SECURITY: This consumer only accepts ``{"type": "heartbeat"}``
-    messages. All other inbound payloads are rejected.
+    Accepted inbound message types:
+    - ``{"type": "heartbeat"}`` — refreshes the wallet's last-active.
+    - ``{"type": "typing", "room_id": ..., "recipients": [...]}`` —
+      broadcasts a typing indicator to each recipient.
+
+    All other inbound payloads are rejected with close code 4001.
     """
 
     def _update_last_active(self):
@@ -109,14 +113,21 @@ class NostrUpdatesConsumer(JsonWebsocketConsumer):
         )
 
     def receive_json(self, content):
-        if content != {"type": "heartbeat"}:
-            logger.warning(
-                f'Nostr WS rejected non-heartbeat from '
-                f'{self.wallet_hash[:16]}...: {content}'
-            )
-            self.close(code=4001)
-            return
+        msg_type = content.get('type') if isinstance(content, dict) else None
 
+        if msg_type == 'heartbeat':
+            return self._handle_heartbeat()
+
+        if msg_type == 'typing':
+            return self._handle_typing(content)
+
+        logger.warning(
+            f'Nostr WS rejected unknown message type from '
+            f'{self.wallet_hash[:16]}...: {content}'
+        )
+        self.close(code=4001)
+
+    def _handle_heartbeat(self):
         user = self.scope.get('user')
         from .utils.auth import verify_wallet_ownership
         ok, reason = verify_wallet_ownership(user, self.wallet_hash)
@@ -129,6 +140,129 @@ class NostrUpdatesConsumer(JsonWebsocketConsumer):
             return
 
         self._update_last_active()
+
+    def _handle_typing(self, content):
+        import re
+        from .models import NostrPubkey
+        from .utils.auth import verify_wallet_ownership
+        from main.utils.cache import set_typing_throttle
+        from .utils.websocket import send_typing_update
+
+        user = self.scope.get('user')
+        ok, reason = verify_wallet_ownership(user, self.wallet_hash)
+        if not ok:
+            logger.warning(
+                f'Nostr WS closing typing for wallet '
+                f'{self.wallet_hash[:16]}... — {reason}'
+            )
+            self.close(code=4001)
+            return
+
+        room_id = content.get('room_id')
+        recipients = content.get('recipients')
+
+        if not room_id or not isinstance(room_id, str):
+            logger.warning(
+                f'Nostr WS rejected typing — missing/invalid room_id from '
+                f'{self.wallet_hash[:16]}...'
+            )
+            self.close(code=4001)
+            return
+
+        if not recipients or not isinstance(recipients, list):
+            logger.warning(
+                f'Nostr WS rejected typing — missing/invalid recipients from '
+                f'{self.wallet_hash[:16]}...'
+            )
+            self.close(code=4001)
+            return
+
+        MAX_RECIPIENTS = 500
+        if len(recipients) > MAX_RECIPIENTS:
+            logger.warning(
+                f'Nostr WS rejected typing — too many recipients '
+                f'({len(recipients)}) from {self.wallet_hash[:16]}...'
+            )
+            self.close(code=4001)
+            return
+
+        for pk in recipients:
+            if not isinstance(pk, str) or not re.match(r'^[0-9a-fA-F]{64}$', pk):
+                logger.warning(
+                    f'Nostr WS rejected typing — invalid recipient pubkey '
+                    f'from {self.wallet_hash[:16]}...'
+                )
+                self.close(code=4001)
+                return
+
+        normalized_recipients = [pk.lower() for pk in recipients]
+
+        np = NostrPubkey.objects.filter(
+            wallet_hash=self.wallet_hash,
+        ).values('pubkey_hex', 'show_active_status').first()
+
+        if not np:
+            logger.warning(
+                f'Nostr WS typing — no NostrPubkey for wallet '
+                f'{self.wallet_hash[:16]}...'
+            )
+            return
+
+        if not np['show_active_status']:
+            logger.info(
+                f'Nostr WS typing — skipping, sender show_active_status=False '
+                f'for wallet {self.wallet_hash[:16]}...'
+            )
+            return
+
+        sender_pubkey = np['pubkey_hex']
+
+        if not set_typing_throttle(sender_pubkey, room_id):
+            logger.info(
+                f'Nostr WS typing — throttled for pubkey '
+                f'{sender_pubkey[:16]}... room {room_id[:16]}...'
+            )
+            return
+
+        room_map = {
+            np_recip['pubkey_hex']: np_recip['wallet_hash']
+            for np_recip in NostrPubkey.objects.filter(
+                pubkey_hex__in=normalized_recipients,
+            ).values('pubkey_hex', 'wallet_hash')
+        }
+
+        for recipient_pubkey in normalized_recipients:
+            recipient_wallet = room_map.get(recipient_pubkey)
+            if recipient_wallet:
+                send_typing_update(recipient_wallet, sender_pubkey, room_id)
+            else:
+                logger.info(
+                    f'Nostr WS typing — recipient {recipient_pubkey[:16]}... '
+                    f'not found — skipping WS push'
+                )
+
+    def typing_update(self, event):
+        """Forward a typing indicator to the connected client."""
+        from .models import NostrPubkey
+
+        can_see = NostrPubkey.objects.filter(
+            wallet_hash=self.wallet_hash,
+            show_active_status=True,
+        ).exists()
+        if not can_see:
+            return
+
+        logger.info(
+            f'Nostr WS received typing_update for wallet '
+            f'{self.wallet_hash[:16]}...: pubkey='
+            f'{event.get("pubkey_hex", "")[:16]}... '
+            f'room={event.get("room_id", "")[:16]}...'
+        )
+        self.send(text_data=json.dumps({
+            'type': 'typing',
+            'pubkey_hex': event['pubkey_hex'],
+            'room_id': event['room_id'],
+        }))
 
     def last_active_update(self, event):
         """Send a last-active timestamp update to the client."""

--- a/nostr/utils/websocket.py
+++ b/nostr/utils/websocket.py
@@ -75,3 +75,64 @@ def send_last_active_update(wallet_hash, pubkey_hex, timestamp):
             f'{wallet_hash}: {e}'
         )
 
+
+def send_typing_update(wallet_hash, sender_pubkey_hex, room_id):
+    """Push a typing indicator to all clients connected for this wallet.
+
+    Skips the push if the sender's ``show_active_status`` is False (they're
+    invisible) or if the recipient's ``show_active_status`` is False (they
+    can't see others' status).
+    """
+    from nostr.models import NostrPubkey
+
+    sender_visible = NostrPubkey.objects.filter(
+        pubkey_hex=sender_pubkey_hex,
+        show_active_status=True,
+    ).exists()
+    if not sender_visible:
+        logger.info(
+            f'Skipping typing WS push — sender pubkey '
+            f'{sender_pubkey_hex[:16]}... has show_active_status=False '
+            f'or not found'
+        )
+        return
+
+    recipient_can_see = NostrPubkey.objects.filter(
+        wallet_hash=wallet_hash,
+        show_active_status=True,
+    ).exists()
+    if not recipient_can_see:
+        logger.info(
+            f'Skipping typing WS push — recipient wallet '
+            f'{wallet_hash[:16]}... has show_active_status=False or not found'
+        )
+        return
+
+    channel_layer = get_channel_layer()
+    if channel_layer is None:
+        logger.warning(
+            f'No channel layer configured — cannot send typing update '
+            f'for wallet {wallet_hash}'
+        )
+        return
+
+    room_group_name = f'nostr_updates_{wallet_hash}'
+
+    try:
+        async_to_sync(channel_layer.group_send)(
+            room_group_name,
+            {
+                'type': 'typing_update',
+                'pubkey_hex': sender_pubkey_hex,
+                'room_id': room_id,
+            },
+        )
+        logger.info(
+            f'Sent typing WS update for wallet {wallet_hash}, '
+            f'pubkey {sender_pubkey_hex[:16]}..., room {room_id[:16]}...'
+        )
+    except Exception as e:
+        logger.error(
+            f'Failed to send typing WS update for wallet {wallet_hash}: {e}'
+        )
+


### PR DESCRIPTION
## Summary

Adds real-time typing indicators to the Nostr chat system, riding on the existing `ws/nostr/updates/<wallet_hash>/` WebSocket connection (no new endpoint, no DB schema changes).

## How it works

Client sends `{"type":"typing","room_id":...,"recipients":[...]}` over the open WS → server derives the sender pubkey from the authenticated connection, applies a 3s Redis throttle per pubkey per room, checks the existing `show_active_status` privacy toggle (mutual consent), and broadcasts `{"type":"typing","pubkey_hex":...,"room_id":...}` to each recipient's WS group.

## Changes

- **`main/utils/cache.py`** — `set_typing_throttle()` / `is_typing_throttled()` Redis helpers (3s TTL, `SET NX EX`).
- **`nostr/utils/websocket.py`** — `send_typing_update()` broadcast helper with the same mutual `show_active_status` privacy check as `send_last_active_update()`.
- **`nostr/consumers.py`** — `receive_json()` now dispatches by `type` (`heartbeat`/`typing`), with `_handle_typing()` (validates `room_id`/`recipients`, re-verifies wallet ownership, applies throttle, broadcasts) and a `typing_update()` handler that forwards the event to the connected client.
- **`docs/NOSTR_TYPING_STATUS_FRONTEND_GUIDE.md`** — frontend integration guide (send format, 3s client throttling, 5s auto-hide, privacy, error table).

## Design decisions

- **WebSocket inbound (not REST)** — lower latency, sender pubkey derived from the authenticated connection (not client-provided, preventing spoofing).
- **3s throttle** — standard for chat apps; server silently drops faster bursts.
- **Reuse `show_active_status`** — typing respects the same privacy toggle as last-active/green-dot, so no new privacy controls are needed.
- **No `stop typing` message** — the 5s client-side auto-hide timer handles it naturally.
- **Strict validation preserved** — malformed typing messages close the connection with code 4001, matching the existing security model.

## No changes needed

- No migrations (typing is transient, not persisted)
- No new REST endpoints / URL routes
- No routing / settings changes

## Testing

Python syntax verified via `py_compile`. Existing test suite requires `firebase_admin` (not installed locally) to run — recommend running `python manage.py test nostr` in a fully provisioned env.