### PR TITLE
Fix/wallet history

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -836,14 +836,15 @@ class WalletHistory(PostgresModel):
             return None
         
         output_fiat_amounts = {}
-        for txn_broadcast in TransactionBroadcast.objects.filter(txid=self.txid):
+        txn_broadcast_qs = TransactionBroadcast.objects.filter(txid=self.txid).order_by("id")
+        for txn_broadcast in txn_broadcast_qs:
             if isinstance(txn_broadcast.output_fiat_amounts, dict):
                 output_fiat_amounts = {
                     **output_fiat_amounts,
                     **txn_broadcast.output_fiat_amounts,
                 }
 
-        if not output_fiat_amounts and not isinstance(output_fiat_amounts, dict):
+        if not output_fiat_amounts:
             return None
         
         fiat_amounts = {}

--- a/main/models.py
+++ b/main/models.py
@@ -831,24 +831,26 @@ class WalletHistory(PostgresModel):
         Always returns the current value from the corresponding TransactionBroadcast record.
         This ensures there is no mismatch between WalletHistory and TransactionBroadcast data.
         """
-        from main.models import TransactionBroadcast
         
         if not self.wallet or not self.txid:
             return None
         
-        try:
-            txn_broadcast = TransactionBroadcast.objects.get(txid=self.txid)
-        except TransactionBroadcast.DoesNotExist:
-            return None
-        
-        if not txn_broadcast.output_fiat_amounts:
+        output_fiat_amounts = {}
+        for txn_broadcast in TransactionBroadcast.objects.filter(txid=self.txid):
+            if isinstance(txn_broadcast.output_fiat_amounts, dict):
+                output_fiat_amounts = {
+                    **output_fiat_amounts,
+                    **txn_broadcast.output_fiat_amounts,
+                }
+
+        if not output_fiat_amounts and not isinstance(output_fiat_amounts, dict):
             return None
         
         fiat_amounts = {}
         
         if self.record_type == WalletHistory.INCOMING:
             # Sum fiat amounts for outputs going to this wallet
-            for output_idx, output_data in txn_broadcast.output_fiat_amounts.items():
+            for output_idx, output_data in output_fiat_amounts.items():
                 recipient = output_data.get('recipient')
                 if not recipient:
                     continue
@@ -876,7 +878,7 @@ class WalletHistory(PostgresModel):
             
             if all_inputs_from_wallet:
                 # Sum fiat amounts for outputs NOT going back to this wallet (exclude change)
-                for output_idx, output_data in txn_broadcast.output_fiat_amounts.items():
+                for output_idx, output_data in output_fiat_amounts.items():
                     recipient = output_data.get('recipient')
                     if not recipient:
                         continue

--- a/main/utils/tx_fee.py
+++ b/main/utils/tx_fee.py
@@ -97,8 +97,8 @@ def get_byte_count(
     for multisig_info in  multisig_inputs:
         total += get_multisig_input_byte_count(**multisig_info)
 
-    total += p2pkh_output_count * 34
-    total += p2sh_output_count * 32
+    total += p2pkh_output_count * 35
+    total += p2sh_output_count * 44
 
     if isinstance(push_data, str):
         total += get

--- a/main/utils/tx_fee.py
+++ b/main/utils/tx_fee.py
@@ -101,7 +101,7 @@ def get_byte_count(
     total += p2sh_output_count * 44
 
     if isinstance(push_data, str):
-        total += get
+        total += get_data_byte_count(push_data)
     elif isinstance(push_data, list):
         for push_data_output in push_data:
             total += get_data_byte_count(push_data_output)


### PR DESCRIPTION
## Description
- Fix potential `MultipleObjectsReturned` error for wallet history api when constructing `fiat_amounts` data, 

## Screenshots (if applicable):
(Include screenshots for UI-related changes)


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Test Notes
Tested manually through shell by accessing `WalletHistory.fiat_amounts` with `TransactionBroadcast.fiat_amounts` data.

## @mentions
Mention the person or team responsible for reviewing the proposed changes.