### PR TITLE
feat: add stop typing websocket message

### DIFF
--- a/nostr/consumers.py
+++ b/nostr/consumers.py
@@ -362,6 +362,15 @@ class NostrUpdatesConsumer(JsonWebsocketConsumer):
 
     def stop_typing_update(self, event):
         """Forward a stop-typing indicator to the connected client."""
+        from .models import NostrPubkey
+
+        can_see = NostrPubkey.objects.filter(
+            wallet_hash=self.wallet_hash,
+            show_active_status=True,
+        ).exists()
+        if not can_see:
+            return
+
         logger.info(
             f'Nostr WS received stop_typing_update for wallet '
             f'{self.wallet_hash[:16]}...: pubkey='

--- a/nostr/consumers.py
+++ b/nostr/consumers.py
@@ -21,6 +21,8 @@ class NostrUpdatesConsumer(JsonWebsocketConsumer):
     - ``{"type": "heartbeat"}`` — refreshes the wallet's last-active.
     - ``{"type": "typing", "room_id": ..., "recipients": [...]}`` —
       broadcasts a typing indicator to each recipient.
+    - ``{"type": "stop_typing", "room_id": ..., "recipients": [...]}`` —
+      broadcasts a stop-typing signal to each recipient.
 
     All other inbound payloads are rejected with close code 4001.
     """
@@ -120,6 +122,9 @@ class NostrUpdatesConsumer(JsonWebsocketConsumer):
 
         if msg_type == 'typing':
             return self._handle_typing(content)
+
+        if msg_type == 'stop_typing':
+            return self._handle_stop_typing(content)
 
         logger.warning(
             f'Nostr WS rejected unknown message type from '
@@ -241,6 +246,97 @@ class NostrUpdatesConsumer(JsonWebsocketConsumer):
                     f'not found — skipping WS push'
                 )
 
+    def _handle_stop_typing(self, content):
+        import re
+        from django.conf import settings
+        from .models import NostrPubkey
+        from .utils.auth import verify_wallet_ownership
+        from .utils.websocket import send_stop_typing_update
+
+        user = self.scope.get('user')
+        ok, reason = verify_wallet_ownership(user, self.wallet_hash)
+        if not ok:
+            logger.warning(
+                f'Nostr WS closing stop_typing for wallet '
+                f'{self.wallet_hash[:16]}... — {reason}'
+            )
+            self.close(code=4001)
+            return
+
+        room_id = content.get('room_id')
+        recipients = content.get('recipients')
+
+        if not room_id or not isinstance(room_id, str):
+            logger.warning(
+                f'Nostr WS rejected stop_typing — missing/invalid room_id from '
+                f'{self.wallet_hash[:16]}...'
+            )
+            self.close(code=4001)
+            return
+
+        if not recipients or not isinstance(recipients, list):
+            logger.warning(
+                f'Nostr WS rejected stop_typing — missing/invalid recipients from '
+                f'{self.wallet_hash[:16]}...'
+            )
+            self.close(code=4001)
+            return
+
+        MAX_RECIPIENTS = 500
+        if len(recipients) > MAX_RECIPIENTS:
+            logger.warning(
+                f'Nostr WS rejected stop_typing — too many recipients '
+                f'({len(recipients)}) from {self.wallet_hash[:16]}...'
+            )
+            self.close(code=4001)
+            return
+
+        for pk in recipients:
+            if not isinstance(pk, str) or not re.match(r'^[0-9a-fA-F]{64}$', pk):
+                logger.warning(
+                    f'Nostr WS rejected stop_typing — invalid recipient pubkey '
+                    f'from {self.wallet_hash[:16]}...'
+                )
+                self.close(code=4001)
+                return
+
+        normalized_recipients = [pk.lower() for pk in recipients]
+
+        np = NostrPubkey.objects.filter(
+            wallet_hash=self.wallet_hash,
+        ).values('pubkey_hex').first()
+
+        if not np:
+            logger.warning(
+                f'Nostr WS stop_typing — no NostrPubkey for wallet '
+                f'{self.wallet_hash[:16]}...'
+            )
+            return
+
+        sender_pubkey = np['pubkey_hex']
+
+        # Clear the typing throttle key so the sender can immediately
+        # send a new typing signal without being blocked by the 3s TTL.
+        cache = settings.REDISKV
+        cache.delete(f'typing:{sender_pubkey}:{room_id}')
+
+        room_map = {
+            np_recip['pubkey_hex']: np_recip['wallet_hash']
+            for np_recip in NostrPubkey.objects.filter(
+                pubkey_hex__in=normalized_recipients,
+            ).values('pubkey_hex', 'wallet_hash')
+        }
+
+        for recipient_pubkey in normalized_recipients:
+            recipient_wallet = room_map.get(recipient_pubkey)
+            if recipient_wallet:
+                send_stop_typing_update(recipient_wallet, sender_pubkey, room_id)
+            else:
+                logger.info(
+                    f'Nostr WS stop_typing — recipient {recipient_pubkey[:16]}... '
+                    f'not found — skipping WS push'
+                )
+
     def typing_update(self, event):
         """Forward a typing indicator to the connected client."""
         from .models import NostrPubkey
@@ -260,6 +356,20 @@ class NostrUpdatesConsumer(JsonWebsocketConsumer):
         )
         self.send(text_data=json.dumps({
             'type': 'typing',
+            'pubkey_hex': event['pubkey_hex'],
+            'room_id': event['room_id'],
+        }))
+
+    def stop_typing_update(self, event):
+        """Forward a stop-typing indicator to the connected client."""
+        logger.info(
+            f'Nostr WS received stop_typing_update for wallet '
+            f'{self.wallet_hash[:16]}...: pubkey='
+            f'{event.get("pubkey_hex", "")[:16]}... '
+            f'room={event.get("room_id", "")[:16]}...'
+        )
+        self.send(text_data=json.dumps({
+            'type': 'stop_typing',
             'pubkey_hex': event['pubkey_hex'],
             'room_id': event['room_id'],
         }))

--- a/nostr/utils/websocket.py
+++ b/nostr/utils/websocket.py
@@ -77,7 +77,36 @@ def send_last_active_update(wallet_hash, pubkey_hex, timestamp):
 
 
 def send_stop_typing_update(wallet_hash, sender_pubkey_hex, room_id):
-    """Push a stop-typing indicator to all clients connected for this wallet."""
+    """Push a stop-typing indicator to all clients connected for this wallet.
+
+    Skips the push if the sender's ``show_active_status`` is False (they're
+    invisible) or if the recipient's ``show_active_status`` is False (they
+    can't see others' status).
+    """
+    from nostr.models import NostrPubkey
+
+    sender_visible = NostrPubkey.objects.filter(
+        pubkey_hex=sender_pubkey_hex,
+        show_active_status=True,
+    ).exists()
+    if not sender_visible:
+        logger.info(
+            f'Skipping stop_typing WS push — sender pubkey '
+            f'{sender_pubkey_hex[:16]}... has show_active_status=False '
+            f'or not found'
+        )
+        return
+
+    recipient_can_see = NostrPubkey.objects.filter(
+        wallet_hash=wallet_hash,
+        show_active_status=True,
+    ).exists()
+    if not recipient_can_see:
+        logger.info(
+            f'Skipping stop_typing WS push — recipient wallet '
+            f'{wallet_hash[:16]}... has show_active_status=False or not found'
+        )
+        return
 
     channel_layer = get_channel_layer()
     if channel_layer is None:

--- a/nostr/utils/websocket.py
+++ b/nostr/utils/websocket.py
@@ -76,6 +76,38 @@ def send_last_active_update(wallet_hash, pubkey_hex, timestamp):
         )
 
 
+def send_stop_typing_update(wallet_hash, sender_pubkey_hex, room_id):
+    """Push a stop-typing indicator to all clients connected for this wallet."""
+
+    channel_layer = get_channel_layer()
+    if channel_layer is None:
+        logger.warning(
+            f'No channel layer configured — cannot send stop_typing update '
+            f'for wallet {wallet_hash}'
+        )
+        return
+
+    room_group_name = f'nostr_updates_{wallet_hash}'
+
+    try:
+        async_to_sync(channel_layer.group_send)(
+            room_group_name,
+            {
+                'type': 'stop_typing_update',
+                'pubkey_hex': sender_pubkey_hex,
+                'room_id': room_id,
+            },
+        )
+        logger.info(
+            f'Sent stop_typing WS update for wallet {wallet_hash}, '
+            f'pubkey {sender_pubkey_hex[:16]}..., room {room_id[:16]}...'
+        )
+    except Exception as e:
+        logger.error(
+            f'Failed to send stop_typing WS update for wallet {wallet_hash}: {e}'
+        )
+
+
 def send_typing_update(wallet_hash, sender_pubkey_hex, room_id):
     """Push a typing indicator to all clients connected for this wallet.
 


### PR DESCRIPTION
Add WebSocket support for a `stop_typing` message type, parallel to the existing `typing` flow.

### What's new

- **Inbound handler** (`_handle_stop_typing`) — validates ownership, room ID, recipients, and pubkey format (same guards as `_handle_typing`), then broadcasts to recipients via `send_stop_typing_update`. Also clears the typing throttle key so senders can immediately retype.

- **Outbound helper** (`send_stop_typing_update`) — pushes a `stop_typing_update` event to the recipient's WS group. Respects `show_active_status` privacy: skips if the sender has opted out of visibility or the recipient cannot see others' status.

- **Event handler** (`stop_typing_update`) — forwards the stop-typing signal to the connected client. Respects `show_active_status` before forwarding.

- **Message routing** — `stop_typing` is now accepted in `receive_json` alongside `heartbeat` and `typing`.