### PR TITLE
feat: synchronous broadcast with Redis locks for double-spend prevention

### DIFF
--- a/main/utils/broadcast.py
+++ b/main/utils/broadcast.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from hashlib import md5
 
 from channels.layers import get_channel_layer
@@ -7,11 +8,155 @@ from Crypto.Hash import SHA256  # pycryptodome
 from main.mqtt import publish_message
 from main.utils.queries.node import Node
 from django.apps import apps
+from django.conf import settings
+from django.utils import timezone
 
-from main.models import Address, Wallet
+from main.models import Address, Wallet, TransactionBroadcast
 
 
 NODE = Node()
+LOGGER = logging.getLogger(__name__)
+
+BROADCAST_LOCK_KEY_PREFIX = 'broadcast:lock'
+BROADCAST_LOCK_TIMEOUT = 30  # seconds
+
+
+def _get_input_outpoints(tx_hex):
+    """Extract input outpoints (txid, vout) from raw transaction hex."""
+    tx = NODE.BCH._decode_raw_transaction(tx_hex)
+    outpoints = []
+    for vin in tx.get('vin', []):
+        if 'txid' in vin and 'vout' in vin:
+            outpoints.append((vin['txid'], vin['vout']))
+    return outpoints
+
+
+def _acquire_broadcast_locks(outpoints):
+    """
+    Acquire Redis locks for all input outpoints to prevent concurrent double-spends.
+    Returns list of lock keys if all acquired, None if any failed.
+    """
+    cache = settings.REDISKV
+    lock_keys = []
+    # Sort outpoints to acquire locks in deterministic order (prevents deadlock)
+    sorted_outpoints = sorted(outpoints)
+    for txid, vout in sorted_outpoints:
+        lock_key = f'{BROADCAST_LOCK_KEY_PREFIX}:{txid}:{vout}'
+        acquired = cache.set(lock_key, '1', nx=True, ex=BROADCAST_LOCK_TIMEOUT)
+        if acquired:
+            lock_keys.append(lock_key)
+        else:
+            # Failed to acquire lock — another broadcast is using this input
+            _release_broadcast_locks(lock_keys)
+            return None
+    return lock_keys
+
+
+def _release_broadcast_locks(lock_keys):
+    """Release Redis locks for input outpoints."""
+    if not lock_keys:
+        return
+    cache = settings.REDISKV
+    for lock_key in lock_keys:
+        try:
+            cache.delete(lock_key)
+        except Exception:
+            pass
+
+
+def broadcast_transaction_sync(transaction_hex, price_log=None, output_fiat_amounts=None):
+    """
+    Synchronously broadcast a transaction to the BCH node.
+
+    This acquires Redis locks on the transaction's input outpoints to prevent
+    concurrent double-spend attempts, then calls test_mempool_accept and
+    sendrawtransaction directly. The caller receives the actual result.
+
+    Returns:
+        dict: {
+            'success': bool,
+            'txid': str or None,
+            'error': str or None,
+            'broadcast_id': int or None,
+        }
+    """
+    result = {'success': False, 'txid': None, 'error': None, 'broadcast_id': None}
+
+    if not NODE.BCH.get_latest_block():
+        result['error'] = 'node unavailable'
+        return result
+
+    # Extract input outpoints for locking
+    try:
+        outpoints = _get_input_outpoints(transaction_hex)
+    except Exception as exc:
+        LOGGER.exception(f'Failed to parse transaction hex: {exc}')
+        result['error'] = f'failed to parse transaction: {exc}'
+        return result
+
+    if not outpoints:
+        result['error'] = 'transaction has no spendable inputs'
+        return result
+
+    # Acquire locks on all input outpoints to prevent concurrent double-spends
+    lock_keys = _acquire_broadcast_locks(outpoints)
+    if lock_keys is None:
+        result['error'] = 'transaction inputs are being broadcast by another request'
+        return result
+
+    try:
+        # Check if transaction would be accepted to mempool
+        test_accept = NODE.BCH.test_mempool_accept(transaction_hex)
+        txid = test_accept['txid']
+        result['txid'] = txid
+
+        if not test_accept['allowed']:
+            result['error'] = test_accept.get('reject-reason', 'transaction rejected by mempool')
+            return result
+
+        # Create TransactionBroadcast record
+        txn_broadcast = TransactionBroadcast(
+            txid=txid,
+            tx_hex=transaction_hex,
+            price_log=price_log,
+            output_fiat_amounts=output_fiat_amounts
+        )
+        txn_broadcast.save()
+        result['broadcast_id'] = txn_broadcast.id
+
+        # Actually broadcast to the node
+        try:
+            broadcasted_txid = NODE.BCH.broadcast_transaction(transaction_hex)
+            if broadcasted_txid:
+                TransactionBroadcast.objects.filter(id=txn_broadcast.id).update(
+                    date_succeeded=timezone.now()
+                )
+                result['success'] = True
+                result['txid'] = broadcasted_txid
+                LOGGER.info(f'Synchronous broadcast succeeded for txid {broadcasted_txid}')
+            else:
+                result['error'] = 'broadcast returned empty txid'
+                LOGGER.warning(f'Broadcast returned empty txid for {txid}')
+        except Exception as exc:
+            error = str(exc)
+            if 'already have transaction' in error:
+                # Transaction is already in mempool — treat as success
+                TransactionBroadcast.objects.filter(id=txn_broadcast.id).update(
+                    date_succeeded=timezone.now()
+                )
+                result['success'] = True
+                result['txid'] = txid
+                LOGGER.info(f'Transaction {txid} already in mempool')
+            else:
+                # Real broadcast failure — record error and return failure
+                TransactionBroadcast.objects.filter(id=txn_broadcast.id).update(error=error)
+                result['error'] = error
+                LOGGER.error(f'Broadcast failed for txid {txid}: {error}')
+    finally:
+        _release_broadcast_locks(lock_keys)
+
+    return result
+
 
 def send_post_broadcast_notifications(transaction, extra_data:dict=None):
     results = []

--- a/main/utils/broadcast.py
+++ b/main/utils/broadcast.py
@@ -42,7 +42,11 @@ def _acquire_broadcast_locks(outpoints):
     sorted_outpoints = sorted(outpoints)
     for txid, vout in sorted_outpoints:
         lock_key = f'{BROADCAST_LOCK_KEY_PREFIX}:{txid}:{vout}'
-        acquired = cache.set(lock_key, '1', nx=True, ex=BROADCAST_LOCK_TIMEOUT)
+        try:
+            acquired = cache.set(lock_key, '1', nx=True, ex=BROADCAST_LOCK_TIMEOUT)
+        except Exception:
+            _release_broadcast_locks(lock_keys)
+            return None
         if acquired:
             lock_keys.append(lock_key)
         else:
@@ -106,12 +110,17 @@ def broadcast_transaction_sync(transaction_hex, price_log=None, output_fiat_amou
 
     try:
         # Check if transaction would be accepted to mempool
-        test_accept = NODE.BCH.test_mempool_accept(transaction_hex)
-        txid = test_accept['txid']
-        result['txid'] = txid
+        try:
+            test_accept = NODE.BCH.test_mempool_accept(transaction_hex)
+            txid = test_accept['txid']
+            result['txid'] = txid
 
-        if not test_accept['allowed']:
-            result['error'] = test_accept.get('reject-reason', 'transaction rejected by mempool')
+            if not test_accept['allowed']:
+                result['error'] = test_accept.get('reject-reason', 'transaction rejected by mempool')
+                return result
+        except Exception as exc:
+            LOGGER.exception(f'Node RPC error during mempool acceptance test: {exc}')
+            result['error'] = f'node rpc error: {exc}'
             return result
 
         # Create TransactionBroadcast record
@@ -136,10 +145,11 @@ def broadcast_transaction_sync(transaction_hex, price_log=None, output_fiat_amou
                 LOGGER.info(f'Synchronous broadcast succeeded for txid {broadcasted_txid}')
             else:
                 result['error'] = 'broadcast returned empty txid'
+                TransactionBroadcast.objects.filter(id=txn_broadcast.id).update(error='broadcast returned empty txid')
                 LOGGER.warning(f'Broadcast returned empty txid for {txid}')
         except Exception as exc:
             error = str(exc)
-            if 'already have transaction' in error:
+            if 'already have transaction' in error.lower():
                 # Transaction is already in mempool — treat as success
                 TransactionBroadcast.objects.filter(id=txn_broadcast.id).update(
                     date_succeeded=timezone.now()

--- a/main/views/view_broadcast.py
+++ b/main/views/view_broadcast.py
@@ -6,7 +6,8 @@ from rest_framework.views import APIView
 from main import serializers
 from main.models import TransactionBroadcast, AssetPriceLog
 from main.utils.queries.node import Node
-from main.tasks import broadcast_transaction, send_post_broadcast_notifications_task
+from main.utils.broadcast import broadcast_transaction_sync
+from main.tasks import send_post_broadcast_notifications_task, process_mempool_transaction_fast
 import logging
 
 NODE = Node()
@@ -32,24 +33,38 @@ class BroadcastViewSet(generics.GenericAPIView):
                 except AssetPriceLog.DoesNotExist:
                     LOGGER.warning(f"price_id {price_id} not found")
             
-            if NODE.BCH.get_latest_block(): # check if node is up
-                test_accept = NODE.BCH.test_mempool_accept(transaction)
-                txid = test_accept['txid']
-                if test_accept['allowed']:
-                    txn_broadcast = TransactionBroadcast(
-                        txid=txid,
-                        tx_hex=transaction,
-                        price_log=price_log,
-                        output_fiat_amounts=output_fiat_amounts
-                    )
-                    txn_broadcast.save()
-                    broadcast_transaction.delay(transaction, txid, txn_broadcast.id)
+            # Synchronous broadcast — only return success after the node confirms
+            # the transaction is in its mempool. This prevents false-positive
+            # success responses when the actual broadcast fails (e.g. txn-mempool-conflict).
+            # Redis locks on input outpoints prevent concurrent double-spend attempts.
+            broadcast_result = broadcast_transaction_sync(
+                transaction,
+                price_log=price_log,
+                output_fiat_amounts=output_fiat_amounts,
+            )
+            
+            if broadcast_result['success']:
+                txid = broadcast_result['txid']
+                response['txid'] = txid
+                response['success'] = True
+                
+                # The transaction is confirmed in the mempool at this point.
+                # Trigger async post-broadcast processing (mempool tx processing
+                # and notifications) without blocking the HTTP response.
+                try:
+                    process_mempool_transaction_fast.delay(txid, transaction, True)
+                except Exception as exc:
+                    LOGGER.error(f'Failed to queue mempool processing for {txid}: {exc}')
+                
+                try:
                     send_post_broadcast_notifications_task.delay(transaction)
-                    response['txid'] = txid
-                    response['success'] = True
-                else:
-                    response['error'] = test_accept['reject-reason']
-                return Response(response, status=status.HTTP_200_OK)
+                except Exception as exc:
+                    LOGGER.error(f'Failed to queue post-broadcast notifications for {txid}: {exc}')
+            else:
+                response['txid'] = broadcast_result.get('txid')
+                response['error'] = broadcast_result.get('error', 'broadcast failed')
+            
+            return Response(response, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 

--- a/main/views/view_broadcast.py
+++ b/main/views/view_broadcast.py
@@ -5,12 +5,10 @@ from rest_framework import status
 from rest_framework.views import APIView
 from main import serializers
 from main.models import TransactionBroadcast, AssetPriceLog
-from main.utils.queries.node import Node
 from main.utils.broadcast import broadcast_transaction_sync
 from main.tasks import send_post_broadcast_notifications_task, process_mempool_transaction_fast
 import logging
 
-NODE = Node()
 LOGGER = logging.getLogger(__name__)
 
 class BroadcastViewSet(generics.GenericAPIView):

--- a/paytacagifts/views/gift.py
+++ b/paytacagifts/views/gift.py
@@ -11,6 +11,7 @@ from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from main.utils.subscription import new_subscription
 from main.utils.queries.node import Node
+from main.utils.broadcast import broadcast_transaction_sync
 from main.models import Transaction, TransactionMetaAttribute, TransactionBroadcast
 from django.db.models import Sum, F, Q
 from datetime import datetime
@@ -229,14 +230,14 @@ class GiftViewSet(viewsets.GenericViewSet):
         # If claim already exists, return early (but still handle transaction_hex if provided)
         if claim:
             txid = None
+            broadcast_error = None
             if transaction_hex:
-                # Extract txid for metadata even if claim exists
-                try:
-                    test_accept = NODE.BCH.test_mempool_accept(transaction_hex)
-                    if test_accept.get('allowed', False):
-                        txid = test_accept.get('txid')
-                except Exception:
-                    pass  # Ignore errors if claim already exists
+                # Synchronous broadcast — only set txid if node confirms the tx is in mempool
+                broadcast_result = broadcast_transaction_sync(transaction_hex)
+                if broadcast_result['success']:
+                    txid = broadcast_result['txid']
+                else:
+                    broadcast_error = broadcast_result.get('error')
             
             # Create or update transaction metadata if txid is available
             if txid:
@@ -249,19 +250,6 @@ class GiftViewSet(viewsets.GenericViewSet):
                         value="Gift"
                     )
                 )
-
-                # Use the same async broadcast pipeline as /api/broadcast/
-                # (save a TransactionBroadcast record then enqueue Celery broadcast task)
-                try:
-                    txn_broadcast = TransactionBroadcast.objects.create(
-                        txid=txid,
-                        tx_hex=transaction_hex,
-                    )
-                    from main.tasks import broadcast_transaction
-                    broadcast_transaction.delay(transaction_hex, txid, txn_broadcast.id)
-                except Exception:
-                    # Don't fail the request if async pipeline can't be queued
-                    pass
             
             # Build response - old clients get original format, new clients get enhanced format
             response_data = {
@@ -270,11 +258,14 @@ class GiftViewSet(viewsets.GenericViewSet):
                 "claim_id": str(claim.id)
             }
             if transaction_hex:
-                # New clients get success and encrypted_gift_code
-                response_data["success"] = True
                 response_data["encrypted_gift_code"] = gift.encrypted_gift_code or ''
                 if txid:
+                    response_data["success"] = True
                     response_data["txid"] = txid
+                else:
+                    response_data["success"] = False
+                    if broadcast_error:
+                        response_data["message"] = f"Transaction broadcast failed: {broadcast_error}"
             return Response(response_data)
 
         # Check campaign limits BEFORE broadcasting transaction
@@ -318,51 +309,18 @@ class GiftViewSet(viewsets.GenericViewSet):
         # Now that limit check passed, handle transaction broadcasting if provided
         txid = None
         if transaction_hex:
-            # Match /api/broadcast/ behavior: do mempool test in-request,
-            # then broadcast asynchronously via Celery to avoid latency spikes.
-            # Check if node is available (fast failure vs long waits elsewhere)
-            if not NODE.BCH.get_latest_block():
-                return Response({
-                    "success": False,
-                    "message": "Blockchain node is not available",
-                }, status=503)
-
-            # Test mempool acceptance
-            try:
-                test_accept = NODE.BCH.test_mempool_accept(transaction_hex)
-                if not test_accept.get('allowed', False):
-                    reject_reason = test_accept.get('reject-reason', 'Unknown error')
-                    return Response({
-                        "success": False,
-                        "message": f"Transaction rejected by mempool: {reject_reason}",
-                    }, status=400)
-                # Extract txid for later use in metadata
-                txid = test_accept.get('txid')
-            except Exception as exc:
-                error_msg = str(exc)
-                LOGGER.exception(f"Error testing mempool acceptance: {exc}")
-                return Response({
-                    "success": False,
-                    "message": f"Error testing mempool acceptance: {error_msg}",
-                }, status=400)
-
-            # Save broadcast attempt and enqueue async broadcaster (same as /api/broadcast/)
-            try:
-                txn_broadcast = TransactionBroadcast.objects.create(
-                    txid=txid,
-                    tx_hex=transaction_hex,
-                )
-                from main.tasks import broadcast_transaction
-                broadcast_transaction.delay(transaction_hex, txid, txn_broadcast.id)
-            except Exception as exc:
-                # If we cannot enqueue the async broadcast pipeline, fail like the old behavior.
-                # This keeps semantics closer to "broadcast requested" even though actual send is async.
-                error_msg = str(exc)
-                LOGGER.exception(f"Error queueing transaction broadcast: {exc}")
+            # Synchronous broadcast — only proceed if node confirms the tx is in mempool.
+            # This prevents false-positive success responses when the actual broadcast fails.
+            broadcast_result = broadcast_transaction_sync(transaction_hex)
+            if not broadcast_result['success']:
+                error_msg = broadcast_result.get('error', 'broadcast failed')
+                # Map node-unavailable to 503, other errors to 400
+                http_status = 503 if error_msg == 'node unavailable' else 400
                 return Response({
                     "success": False,
                     "message": f"Transaction broadcast failed: {error_msg}",
-                }, status=400)
+                }, status=http_status)
+            txid = broadcast_result['txid']
         
         # Create the claim record (limit check already passed)
         if gift.campaign:
@@ -468,50 +426,19 @@ class GiftViewSet(viewsets.GenericViewSet):
             if gift.date_claimed is not None:
                 raise Exception("This gift has been claimed.")
             
-            # Handle transaction broadcasting if provided (match /api/broadcast/ behavior)
+            # Handle transaction broadcasting if provided
             txid = None
             if transaction_hex:
-                # Check if node is available
-                if not NODE.BCH.get_latest_block():
-                    return Response({
-                        "success": False,
-                        "message": "Blockchain node is not available",
-                    }, status=503)
-                
-                # Test mempool acceptance
-                try:
-                    test_accept = NODE.BCH.test_mempool_accept(transaction_hex)
-                    if not test_accept.get('allowed', False):
-                        reject_reason = test_accept.get('reject-reason', 'Unknown error')
-                        return Response({
-                            "success": False,
-                            "message": f"Transaction rejected by mempool: {reject_reason}",
-                        }, status=400)
-                    # Extract txid for later use in metadata
-                    txid = test_accept.get('txid')
-                except Exception as exc:
-                    error_msg = str(exc)
-                    LOGGER.exception(f"Error testing mempool acceptance: {exc}")
-                    return Response({
-                        "success": False,
-                        "message": f"Error testing mempool acceptance: {error_msg}",
-                    }, status=400)
-
-                # Save broadcast attempt and enqueue async broadcaster (same as /api/broadcast/)
-                try:
-                    txn_broadcast = TransactionBroadcast.objects.create(
-                        txid=txid,
-                        tx_hex=transaction_hex,
-                    )
-                    from main.tasks import broadcast_transaction
-                    broadcast_transaction.delay(transaction_hex, txid, txn_broadcast.id)
-                except Exception as exc:
-                    error_msg = str(exc)
-                    LOGGER.exception(f"Error queueing transaction broadcast: {exc}")
+                # Synchronous broadcast — only proceed if node confirms the tx is in mempool.
+                broadcast_result = broadcast_transaction_sync(transaction_hex)
+                if not broadcast_result['success']:
+                    error_msg = broadcast_result.get('error', 'broadcast failed')
+                    http_status = 503 if error_msg == 'node unavailable' else 400
                     return Response({
                         "success": False,
                         "message": f"Transaction broadcast failed: {error_msg}",
-                    }, status=400)
+                    }, status=http_status)
+                txid = broadcast_result['txid']
             
             # Check if a claim already exists for this wallet (from previous recovery attempt)
             # If it exists, we can still allow recovery (return the data without creating duplicate claim)

--- a/paytacagifts/views/gift.py
+++ b/paytacagifts/views/gift.py
@@ -10,15 +10,12 @@ from paytacagifts.models import Gift, Wallet, Campaign, Claim
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from main.utils.subscription import new_subscription
-from main.utils.queries.node import Node
 from main.utils.broadcast import broadcast_transaction_sync
-from main.models import Transaction, TransactionMetaAttribute, TransactionBroadcast
+from main.models import TransactionMetaAttribute
 from django.db.models import Sum, F, Q
-from datetime import datetime
 import logging
 import hashlib
 
-NODE = Node()
 LOGGER = logging.getLogger(__name__)
 
 class GiftViewSet(viewsets.GenericViewSet):

--- a/paytacapos/utils/broadcast.py
+++ b/paytacapos/utils/broadcast.py
@@ -1,18 +1,15 @@
-from main.tasks import broadcast_transaction as broadcast_tx
-from main.utils.broadcast import send_post_broadcast_notifications
+from main.utils.broadcast import broadcast_transaction_sync, send_post_broadcast_notifications
 
 def broadcast_transaction(tx_hex):
     response = { "success": False }
 
-    success, result = broadcast_tx(tx_hex)
-    if "already have transaction" in result:
-        success = True
-    if success:
+    broadcast_result = broadcast_transaction_sync(tx_hex)
+    if broadcast_result['success']:
         send_post_broadcast_notifications(tx_hex)
-        response["txid"] = result.split(" ")[-1]
+        response["txid"] = broadcast_result['txid']
         response["success"] = True
         return response
     else:
-        response["error"] = result
+        response["error"] = broadcast_result.get('error', 'broadcast failed')
         response["success"] = False
         return response


### PR DESCRIPTION
## Rationale

The previous broadcast architecture used an **async-only** pattern: the API would test mempool acceptance, return `success: true` to the client, then enqueue a Celery task to actually broadcast. This created a window where the client received a false-positive success response even when the real broadcast later failed (e.g., `txn-mempool-conflict`). This was especially problematic for gift claims where the claim was already created and the client was told the broadcast succeeded.

## Changes

### `main/utils/broadcast.py` — New `broadcast_transaction_sync()`
- Extracts input outpoints from the raw transaction hex
- Acquires **Redis locks** on each outpoint (`BROADCAST_LOCK_KEY_PREFIX`) to prevent concurrent double-spend attempts from overlapping requests
- Locks are acquired in **sorted order** to prevent deadlock
- Calls `test_mempool_accept` + `sendrawtransaction` **synchronously** within the HTTP request
- Treats `"already have transaction"` errors as success (idempotent re-broadcast)
- Creates a `TransactionBroadcast` DB record with success/error timestamps
- Releases all locks in a `finally` block
- Timeout of 30s prevents stale locks from accumulating

### `main/views/view_broadcast.py` — `/api/broadcast/` endpoint
- Replaced `test_mempool_accept` + `broadcast_transaction.delay()` with `broadcast_transaction_sync()`
- Only returns `success: true` after the node confirms the transaction is in its mempool
- Queues `process_mempool_transaction_fast` and `send_post_broadcast_notifications_task` as **fire-and-forget** after sync success (non-blocking)

### `paytacagifts/views/gift.py` — Gift claim endpoints
- All three endpoints (`claim`, `campaign_claim`, `recover_claim`) now use `broadcast_transaction_sync()`
- Eliminated the duplicated `test_mempool_accept` + Celery task pattern across all three endpoints
- Better error handling: `node unavailable` → 503, other errors → 400
- Returns `success: false` with a clear error message when broadcast fails, instead of the old false-positive `success: true`

### `paytacapos/utils/broadcast.py` — POS broadcast utility
- Simplified to use `broadcast_transaction_sync()` instead of the old Celery-based `broadcast_transaction` task
- Same reliability guarantees — no more string-parsing of Celery task results

## Benefits
- **No false-positive success responses** — client only sees success when the node confirms
- **Double-spend prevention** — Redis locks prevent concurrent broadcasts using the same inputs
- **Simpler code** — eliminated the broadcast Celery task dependency from all three gift endpoints
- **Consistent behavior** — all broadcast paths now use the same synchronous pipeline