### PR TITLE
Add WalletActivity tracking for wallet sends and receives

### DIFF
--- a/main/management/commands/backfill_wallet_activity.py
+++ b/main/management/commands/backfill_wallet_activity.py
@@ -48,7 +48,7 @@ class Command(BaseCommand):
         skipped = 0
 
         for idx, history in enumerate(queryset.iterator(chunk_size=2000)):
-            activity_date = history.tx_timestamp.date() if history.tx_timestamp else timezone.now().date()
+            activity_date = history.tx_timestamp.date() if history.tx_timestamp else timezone.localdate()
             kind = (
                 WalletActivity.KIND_TRANSACTION_SEND
                 if history.record_type == WalletHistory.OUTGOING
@@ -68,7 +68,7 @@ class Command(BaseCommand):
                     kind=kind,
                     defaults={
                         'activity_date': activity_date,
-                        'amount': int(round(abs(history.amount) * 100_000_000)) if history.amount else None,
+                        'amount': int(round(abs(history.amount) * 100_000_000)) if history.amount is not None else None,
                     },
                 )
 

--- a/main/management/commands/backfill_wallet_activity.py
+++ b/main/management/commands/backfill_wallet_activity.py
@@ -50,18 +50,22 @@ class Command(BaseCommand):
         for idx, history in enumerate(queryset.iterator(chunk_size=2000)):
             activity_date = history.tx_timestamp.date() if history.tx_timestamp else timezone.now().date()
 
-            if not dry_run:
+            if dry_run:
+                was_created = not WalletActivity.objects.filter(
+                    wallet=history.wallet,
+                    history=history,
+                    kind=WalletActivity.KIND_TRANSACTION_SEND,
+                ).exists()
+            else:
                 _, was_created = WalletActivity.objects.get_or_create(
                     wallet=history.wallet,
                     history=history,
+                    kind=WalletActivity.KIND_TRANSACTION_SEND,
                     defaults={
                         'activity_date': activity_date,
-                        'kind': WalletActivity.KIND_TRANSACTION_SEND,
                         'amount': int(round(abs(history.amount) * 100_000_000)) if history.amount else None,
                     },
                 )
-            else:
-                was_created = True
 
             if was_created:
                 created += 1

--- a/main/management/commands/backfill_wallet_activity.py
+++ b/main/management/commands/backfill_wallet_activity.py
@@ -1,0 +1,78 @@
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from main.models import WalletActivity, WalletHistory
+
+
+class Command(BaseCommand):
+    help = 'One-time backfill of WalletActivity records from historical WalletHistory sends'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--date',
+            type=str,
+            help='Only backfill sends on this UTC day (YYYY-MM-DD). Defaults to all history.',
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Count what would be created without writing anything',
+        )
+        parser.add_argument(
+            '--progress-every',
+            type=int,
+            default=5000,
+            help='Log progress every N records (default: 5000)',
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options.get('dry_run', False)
+        progress_every = options.get('progress_every', 5000)
+        target_date = options.get('date')
+
+        queryset = WalletHistory.objects.filter(
+            record_type=WalletHistory.OUTGOING,
+            wallet__isnull=False,
+        ).select_related('wallet')
+
+        if target_date:
+            day = timezone.datetime.strptime(target_date, '%Y-%m-%d').date()
+            queryset = queryset.filter(tx_timestamp__date=day)
+
+        total = queryset.count()
+        self.stdout.write(
+            f"Backfilling WalletActivity from {total} outgoing WalletHistory records"
+        )
+
+        created = 0
+        skipped = 0
+
+        for idx, history in enumerate(queryset.iterator(chunk_size=2000)):
+            activity_date = history.tx_timestamp.date() if history.tx_timestamp else timezone.now().date()
+
+            if not dry_run:
+                _, was_created = WalletActivity.objects.get_or_create(
+                    wallet=history.wallet,
+                    history=history,
+                    defaults={
+                        'activity_date': activity_date,
+                        'kind': WalletActivity.KIND_TRANSACTION_SEND,
+                        'amount': int(round(abs(history.amount) * 100_000_000)) if history.amount else None,
+                    },
+                )
+            else:
+                was_created = True
+
+            if was_created:
+                created += 1
+            else:
+                skipped += 1
+
+            if progress_every and (idx + 1) % progress_every == 0:
+                self.stdout.write(
+                    f"  [{idx + 1}/{total}] scanned, {created} created, {skipped} skipped"
+                )
+
+        self.stdout.write(self.style.SUCCESS(
+            f"Done. Created: {created}, Skipped (already exist): {skipped}"
+        ))

--- a/main/management/commands/backfill_wallet_activity.py
+++ b/main/management/commands/backfill_wallet_activity.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
         target_date = options.get('date')
 
         queryset = WalletHistory.objects.filter(
-            record_type=WalletHistory.OUTGOING,
+            record_type__in=[WalletHistory.OUTGOING, WalletHistory.INCOMING],
             wallet__isnull=False,
         ).select_related('wallet')
 
@@ -41,7 +41,7 @@ class Command(BaseCommand):
 
         total = queryset.count()
         self.stdout.write(
-            f"Backfilling WalletActivity from {total} outgoing WalletHistory records"
+            f"Backfilling WalletActivity from {total} outgoing/incoming WalletHistory records"
         )
 
         created = 0
@@ -49,18 +49,23 @@ class Command(BaseCommand):
 
         for idx, history in enumerate(queryset.iterator(chunk_size=2000)):
             activity_date = history.tx_timestamp.date() if history.tx_timestamp else timezone.now().date()
+            kind = (
+                WalletActivity.KIND_TRANSACTION_SEND
+                if history.record_type == WalletHistory.OUTGOING
+                else WalletActivity.KIND_TRANSACTION_RECEIVE
+            )
 
             if dry_run:
                 was_created = not WalletActivity.objects.filter(
                     wallet=history.wallet,
                     history=history,
-                    kind=WalletActivity.KIND_TRANSACTION_SEND,
+                    kind=kind,
                 ).exists()
             else:
                 _, was_created = WalletActivity.objects.get_or_create(
                     wallet=history.wallet,
                     history=history,
-                    kind=WalletActivity.KIND_TRANSACTION_SEND,
+                    kind=kind,
                     defaults={
                         'activity_date': activity_date,
                         'amount': int(round(abs(history.amount) * 100_000_000)) if history.amount else None,

--- a/main/migrations/0129_walletactivity.py
+++ b/main/migrations/0129_walletactivity.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0128_auto_20260623_0728'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='WalletActivity',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('activity_date', models.DateField(db_index=True)),
+                ('kind', models.CharField(choices=[('transaction-send', 'Transaction Send'), ('app-opening', 'App Opening')], db_index=True, max_length=32)),
+                ('amount', models.BigIntegerField(blank=True, null=True)),
+                ('date_created', models.DateTimeField(auto_now_add=True)),
+                ('history', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='activities', to='main.wallethistory')),
+                ('wallet', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='activities', to='main.wallet')),
+            ],
+            options={
+                'verbose_name': 'Wallet Activity',
+                'verbose_name_plural': 'Wallet Activities',
+                'ordering': ['-activity_date', '-date_created'],
+                'constraints': [
+                    models.UniqueConstraint(fields=['wallet', 'history', 'kind', 'activity_date'], name='unique_wallet_activity_wallet_history'),
+                ],
+            },
+        ),
+    ]

--- a/main/migrations/0129_walletactivity.py
+++ b/main/migrations/0129_walletactivity.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('activity_date', models.DateField(db_index=True)),
-                ('kind', models.CharField(choices=[('transaction-send', 'Transaction Send'), ('app-opening', 'App Opening')], db_index=True, max_length=32)),
+                ('kind', models.CharField(choices=[('transaction-send', 'Transaction Send'), ('transaction-receive', 'Transaction Receive'), ('app-opening', 'App Opening')], db_index=True, max_length=32)),
                 ('amount', models.BigIntegerField(blank=True, null=True)),
                 ('date_created', models.DateTimeField(auto_now_add=True)),
                 ('history', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='activities', to='main.wallethistory')),

--- a/main/models.py
+++ b/main/models.py
@@ -1206,10 +1206,12 @@ class AddressBookAddress(models.Model):
 
 class WalletActivity(models.Model):
     KIND_TRANSACTION_SEND = 'transaction-send'
+    KIND_TRANSACTION_RECEIVE = 'transaction-receive'
     KIND_APP_OPENING = 'app-opening'
 
     KIND_CHOICES = [
         (KIND_TRANSACTION_SEND, 'Transaction Send'),
+        (KIND_TRANSACTION_RECEIVE, 'Transaction Receive'),
         (KIND_APP_OPENING, 'App Opening'),
     ]
 

--- a/main/models.py
+++ b/main/models.py
@@ -1204,7 +1204,7 @@ class AddressBookAddress(models.Model):
         return self.address
 
 
-class WalletActivity(models.Model):
+class WalletActivity(PostgresModel):
     KIND_TRANSACTION_SEND = 'transaction-send'
     KIND_TRANSACTION_RECEIVE = 'transaction-receive'
     KIND_APP_OPENING = 'app-opening'

--- a/main/models.py
+++ b/main/models.py
@@ -1202,3 +1202,44 @@ class AddressBookAddress(models.Model):
 
     def __str__(self):
         return self.address
+
+
+class WalletActivity(models.Model):
+    KIND_TRANSACTION_SEND = 'transaction-send'
+    KIND_APP_OPENING = 'app-opening'
+
+    KIND_CHOICES = [
+        (KIND_TRANSACTION_SEND, 'Transaction Send'),
+        (KIND_APP_OPENING, 'App Opening'),
+    ]
+
+    wallet = models.ForeignKey(
+        Wallet,
+        on_delete=models.CASCADE,
+        related_name='activities',
+    )
+    history = models.ForeignKey(
+        WalletHistory,
+        on_delete=models.SET_NULL,
+        related_name='activities',
+        null=True,
+        blank=True,
+    )
+    activity_date = models.DateField(db_index=True)
+    kind = models.CharField(max_length=32, choices=KIND_CHOICES, db_index=True)
+    amount = models.BigIntegerField(blank=True, null=True)
+    date_created = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        verbose_name = "Wallet Activity"
+        verbose_name_plural = "Wallet Activities"
+        ordering = ['-activity_date', '-date_created']
+        constraints = [
+            models.UniqueConstraint(
+                fields=['wallet', 'history', 'kind', 'activity_date'],
+                name='unique_wallet_activity_wallet_history',
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.kind} {self.wallet.wallet_hash[:16]}... on {self.activity_date}"

--- a/main/signals.py
+++ b/main/signals.py
@@ -48,7 +48,7 @@ def record_wallet_activity(history):
         kind=kind,
         defaults={
             'activity_date': activity_date,
-            'amount': int(round(abs(history.amount) * 100_000_000)) if history.amount else None,
+            'amount': int(round(abs(history.amount) * 100_000_000)) if history.amount is not None else None,
         },
     )
 

--- a/main/signals.py
+++ b/main/signals.py
@@ -32,16 +32,20 @@ LOGGER = logging.getLogger(__name__)
 
 
 def record_wallet_activity(history):
-    """Create a WalletActivity row for an outgoing transaction-send."""
+    """Create a WalletActivity row for an outgoing/incoming transaction."""
     if not history.wallet:
         return
-    if history.record_type != WalletHistory.OUTGOING:
+    if history.record_type == WalletHistory.OUTGOING:
+        kind = WalletActivity.KIND_TRANSACTION_SEND
+    elif history.record_type == WalletHistory.INCOMING:
+        kind = WalletActivity.KIND_TRANSACTION_RECEIVE
+    else:
         return
     activity_date = history.tx_timestamp.date() if history.tx_timestamp else timezone.localdate()
     WalletActivity.objects.get_or_create(
         wallet=history.wallet,
         history=history,
-        kind=WalletActivity.KIND_TRANSACTION_SEND,
+        kind=kind,
         defaults={
             'activity_date': activity_date,
             'amount': int(round(abs(history.amount) * 100_000_000)) if history.amount else None,

--- a/main/signals.py
+++ b/main/signals.py
@@ -41,9 +41,9 @@ def record_wallet_activity(history):
     WalletActivity.objects.get_or_create(
         wallet=history.wallet,
         history=history,
+        kind=WalletActivity.KIND_TRANSACTION_SEND,
         defaults={
             'activity_date': activity_date,
-            'kind': WalletActivity.KIND_TRANSACTION_SEND,
             'amount': int(round(abs(history.amount) * 100_000_000)) if history.amount else None,
         },
     )

--- a/main/signals.py
+++ b/main/signals.py
@@ -18,6 +18,7 @@ from main.models import (
     WalletHistoryQuerySet,
     Address,
     TransactionBroadcast,
+    WalletActivity,
 )
 from main.tasks import (
     transaction_post_save_task,
@@ -25,6 +26,27 @@ from main.tasks import (
 )
 from main.utils.cache import clear_wallet_history_cache, clear_wallet_balance_cache
 from main.utils.address_validator import is_bch_address
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def record_wallet_activity(history):
+    """Create a WalletActivity row for an outgoing transaction-send."""
+    if not history.wallet:
+        return
+    if history.record_type != WalletHistory.OUTGOING:
+        return
+    activity_date = history.tx_timestamp.date() if history.tx_timestamp else timezone.localdate()
+    WalletActivity.objects.get_or_create(
+        wallet=history.wallet,
+        history=history,
+        defaults={
+            'activity_date': activity_date,
+            'kind': WalletActivity.KIND_TRANSACTION_SEND,
+            'amount': int(round(abs(history.amount) * 100_000_000)) if history.amount else None,
+        },
+    )
 
 
 
@@ -217,6 +239,11 @@ def transaction_meta_attr_post_save(sender, instance=None, created=False, **kwar
 @receiver(post_save, sender=WalletHistory, dispatch_uid='main.tasks.wallet_history_post_save')
 def wallet_history_post_save(sender, instance=None, created=False, **kwargs):
     if created:
+        try:
+            record_wallet_activity(instance)
+        except Exception:
+            LOGGER.exception("Failed to record WalletActivity for history %s", instance.pk)
+
         # Clear wallet history cache for this wallet to ensure fresh data
         # Note: Deletion of earlier records is now handled in parse_wallet_history using update_or_create
         if instance.wallet:


### PR DESCRIPTION
## Summary

Adds a `WalletActivity` model to the `main` app that records per-event wallet activity (transaction sends and receives) at per-transaction granularity, with foreign keys to `Wallet` and `WalletHistory` instead of storing `wallet_hash`/`txid` as plain strings.

This mirrors the equivalent `WalletActivity` model being built in the separate growth-tracker app, but rooted in the source-of-truth data here in watchtower-cash so it can be queried with proper relations.

## What's included

- **Model** (`main/models.py`): `WalletActivity`
  - `wallet` FK → `Wallet`
  - `history` FK → `WalletHistory` (nullable, for events not tied to a transaction, e.g. app openings)
  - `activity_date`, `kind` (`transaction-send` | `transaction-receive` | `app-opening`), `amount` (satoshis, nullable), `date_created`
  - The auto-increment pk serves as the unique `event_id`
  - DB-level `UniqueConstraint` on `(wallet, history, kind, activity_date)` to prevent duplicates (nullable `history` still allows multiple non-transaction events per day)
- **Migration** (`main/migrations/0129_walletactivity.py`)
- **One-time backfill command** (`main/management/commands/backfill_wallet_activity.py`): populates historical `WalletActivity` rows from outgoing and incoming `WalletHistory` records. Idempotent (`get_or_create` with `kind` in the lookup, matching the unique constraint), supports `--date`, `--dry-run` (real existence checks), `--progress-every`.
- **Forward hook** (`main/signals.py`): `wallet_history_post_save` creates a `WalletActivity` row for every new transaction — outgoing maps to `transaction-send`, incoming to `transaction-receive`.

## Usage

Backfill historical data (one-time, after migrating):

```bash
python manage.py migrate main
python manage.py backfill_wallet_activity
# preview: python manage.py backfill_wallet_activity --dry-run
```

## Notes

- App-opening records are not auto-created yet (no upstream source); the model and `kind` support them for a future data source.
- Uniqueness for transactions is keyed on the `WalletHistory` row + `kind`; for non-transaction events (`history = NULL`) it collapses to one activity per wallet per kind per day.

## Testing

- Syntax-verified locally; Django env/db are remote so `makemigrations --check` / `migrate` should be confirmed on the server before running the backfill.