### PR TITLE
Refine WalletActivity: BCH wallets only, drop redundant amount

### DIFF
--- a/main/management/commands/backfill_wallet_activity.py
+++ b/main/management/commands/backfill_wallet_activity.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from main.models import WalletActivity, WalletHistory
-from main.utils.wallet_activity import activity_kind_for_history, history_amount_to_satoshis
+from main.utils.wallet_activity import activity_kind_for_history
 
 
 class Command(BaseCommand):
@@ -34,8 +34,7 @@ class Command(BaseCommand):
         queryset = WalletHistory.objects.filter(
             record_type__in=[WalletHistory.OUTGOING, WalletHistory.INCOMING],
             wallet__wallet_type='bch',
-            token__name__iexact='bch',
-        ).select_related('wallet', 'token')
+        ).select_related('wallet')
 
         if target_date:
             day = timezone.datetime.strptime(target_date, '%Y-%m-%d').date()
@@ -69,7 +68,6 @@ class Command(BaseCommand):
                     kind=kind,
                     defaults={
                         'activity_date': activity_date,
-                        'amount': history_amount_to_satoshis(history),
                     },
                 )
 

--- a/main/management/commands/backfill_wallet_activity.py
+++ b/main/management/commands/backfill_wallet_activity.py
@@ -2,16 +2,17 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from main.models import WalletActivity, WalletHistory
+from main.utils.wallet_activity import activity_kind_for_history, history_amount_to_satoshis
 
 
 class Command(BaseCommand):
-    help = 'One-time backfill of WalletActivity records from historical WalletHistory sends'
+    help = 'One-time backfill of WalletActivity records from historical BCH WalletHistory sends/receives'
 
     def add_arguments(self, parser):
         parser.add_argument(
             '--date',
             type=str,
-            help='Only backfill sends on this UTC day (YYYY-MM-DD). Defaults to all history.',
+            help='Only backfill activity on this UTC day (YYYY-MM-DD). Defaults to all history.',
         )
         parser.add_argument(
             '--dry-run',
@@ -32,8 +33,9 @@ class Command(BaseCommand):
 
         queryset = WalletHistory.objects.filter(
             record_type__in=[WalletHistory.OUTGOING, WalletHistory.INCOMING],
-            wallet__isnull=False,
-        ).select_related('wallet')
+            wallet__wallet_type='bch',
+            token__name__iexact='bch',
+        ).select_related('wallet', 'token')
 
         if target_date:
             day = timezone.datetime.strptime(target_date, '%Y-%m-%d').date()
@@ -41,19 +43,18 @@ class Command(BaseCommand):
 
         total = queryset.count()
         self.stdout.write(
-            f"Backfilling WalletActivity from {total} outgoing/incoming WalletHistory records"
+            f"Backfilling WalletActivity from {total} BCH outgoing/incoming WalletHistory records"
         )
 
         created = 0
         skipped = 0
 
         for idx, history in enumerate(queryset.iterator(chunk_size=2000)):
+            kind = activity_kind_for_history(history)
+            if kind is None:
+                continue
+
             activity_date = history.tx_timestamp.date() if history.tx_timestamp else timezone.localdate()
-            kind = (
-                WalletActivity.KIND_TRANSACTION_SEND
-                if history.record_type == WalletHistory.OUTGOING
-                else WalletActivity.KIND_TRANSACTION_RECEIVE
-            )
 
             if dry_run:
                 was_created = not WalletActivity.objects.filter(
@@ -68,7 +69,7 @@ class Command(BaseCommand):
                     kind=kind,
                     defaults={
                         'activity_date': activity_date,
-                        'amount': int(round(abs(history.amount) * 100_000_000)) if history.amount is not None else None,
+                        'amount': history_amount_to_satoshis(history),
                     },
                 )
 

--- a/main/migrations/0130_remove_walletactivity_amount.py
+++ b/main/migrations/0130_remove_walletactivity_amount.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0129_walletactivity'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='walletactivity',
+            name='amount',
+        ),
+    ]

--- a/main/models.py
+++ b/main/models.py
@@ -1229,7 +1229,6 @@ class WalletActivity(PostgresModel):
     )
     activity_date = models.DateField(db_index=True)
     kind = models.CharField(max_length=32, choices=KIND_CHOICES, db_index=True)
-    amount = models.BigIntegerField(blank=True, null=True)
     date_created = models.DateTimeField(auto_now_add=True)
 
     class Meta:

--- a/main/signals.py
+++ b/main/signals.py
@@ -26,7 +26,7 @@ from main.tasks import (
 )
 from main.utils.cache import clear_wallet_history_cache, clear_wallet_balance_cache
 from main.utils.address_validator import is_bch_address
-from main.utils.wallet_activity import activity_kind_for_history, history_amount_to_satoshis
+from main.utils.wallet_activity import activity_kind_for_history
 
 
 LOGGER = logging.getLogger(__name__)
@@ -44,7 +44,6 @@ def record_wallet_activity(history):
         kind=kind,
         defaults={
             'activity_date': activity_date,
-            'amount': history_amount_to_satoshis(history),
         },
     )
 

--- a/main/signals.py
+++ b/main/signals.py
@@ -26,20 +26,16 @@ from main.tasks import (
 )
 from main.utils.cache import clear_wallet_history_cache, clear_wallet_balance_cache
 from main.utils.address_validator import is_bch_address
+from main.utils.wallet_activity import activity_kind_for_history, history_amount_to_satoshis
 
 
 LOGGER = logging.getLogger(__name__)
 
 
 def record_wallet_activity(history):
-    """Create a WalletActivity row for an outgoing/incoming transaction."""
-    if not history.wallet:
-        return
-    if history.record_type == WalletHistory.OUTGOING:
-        kind = WalletActivity.KIND_TRANSACTION_SEND
-    elif history.record_type == WalletHistory.INCOMING:
-        kind = WalletActivity.KIND_TRANSACTION_RECEIVE
-    else:
+    """Create a WalletActivity row for an outgoing/incoming BCH transaction."""
+    kind = activity_kind_for_history(history)
+    if kind is None:
         return
     activity_date = history.tx_timestamp.date() if history.tx_timestamp else timezone.localdate()
     WalletActivity.objects.get_or_create(
@@ -48,7 +44,7 @@ def record_wallet_activity(history):
         kind=kind,
         defaults={
             'activity_date': activity_date,
-            'amount': int(round(abs(history.amount) * 100_000_000)) if history.amount is not None else None,
+            'amount': history_amount_to_satoshis(history),
         },
     )
 

--- a/main/utils/wallet_activity.py
+++ b/main/utils/wallet_activity.py
@@ -1,27 +1,9 @@
 from main.models import WalletActivity, WalletHistory
 
-SATOSHIS_PER_BCH = 100_000_000
-BIGINT_MAX = 9_223_372_036_854_775_807
-
-
-def history_amount_to_satoshis(history):
-    """Convert a WalletHistory BCH amount to satoshis, guarding against overflow."""
-    if history.amount is None:
-        return None
-    try:
-        sats = int(round(abs(history.amount) * SATOSHIS_PER_BCH))
-    except (OverflowError, ValueError):
-        return None
-    if sats > BIGINT_MAX:
-        return None
-    return sats
-
 
 def activity_kind_for_history(history):
     """Map a WalletHistory record to its WalletActivity kind, or None if not tracked."""
     if not history.wallet or history.wallet.wallet_type != 'bch':
-        return None
-    if history.token and history.token.name.lower() != 'bch':
         return None
     if history.record_type == WalletHistory.OUTGOING:
         return WalletActivity.KIND_TRANSACTION_SEND

--- a/main/utils/wallet_activity.py
+++ b/main/utils/wallet_activity.py
@@ -1,0 +1,30 @@
+from main.models import WalletActivity, WalletHistory
+
+SATOSHIS_PER_BCH = 100_000_000
+BIGINT_MAX = 9_223_372_036_854_775_807
+
+
+def history_amount_to_satoshis(history):
+    """Convert a WalletHistory BCH amount to satoshis, guarding against overflow."""
+    if history.amount is None:
+        return None
+    try:
+        sats = int(round(abs(history.amount) * SATOSHIS_PER_BCH))
+    except (OverflowError, ValueError):
+        return None
+    if sats > BIGINT_MAX:
+        return None
+    return sats
+
+
+def activity_kind_for_history(history):
+    """Map a WalletHistory record to its WalletActivity kind, or None if not tracked."""
+    if not history.wallet or history.wallet.wallet_type != 'bch':
+        return None
+    if history.token and history.token.name.lower() != 'bch':
+        return None
+    if history.record_type == WalletHistory.OUTGOING:
+        return WalletActivity.KIND_TRANSACTION_SEND
+    if history.record_type == WalletHistory.INCOMING:
+        return WalletActivity.KIND_TRANSACTION_RECEIVE
+    return None


### PR DESCRIPTION
## Summary

Follow-up to #484 (WalletActivity tracking). This branch refines the model and backfill logic:

1. **Restrict to BCH wallets only** — excludes SLP (`wallet_type='slp'`) and smartBCH (`wallet_type='sbch'`) wallets. Cashtoken transactions on BCH wallets are **still tracked** (the restriction is on wallet type, not token).
2. **Remove redundant `amount` field** — the amount is already available via the `WalletHistory` FK (`history.amount`), so it's not duplicated on `WalletActivity`.

## What's included

- **`main/utils/wallet_activity.py`** (new): shared `activity_kind_for_history()` maps a `WalletHistory` row to its activity `kind`, skipping non-BCH wallets. This also fixes the earlier `bigint out of range` crash by removing the satoshi-conversion path entirely.
- **`main/signals.py`**: `record_wallet_activity()` now uses the shared helper and no longer sets `amount`.
- **`main/management/commands/backfill_wallet_activity.py`**: backfill filters `wallet__wallet_type='bch'`, uses the helper, and no longer stores `amount`.
- **`main/models.py`**: dropped `amount` from `WalletActivity`.
- **Migration** `0130_remove_walletactivity_amount.py`: removes the `amount` column (on top of the already-merged `0129`).

## Notes

- SLP and smartBCH wallets are excluded, matching the growth report's BCH-only wallet scope.
- Cashtoken transactions on BCH wallets remain tracked; asset identity is available through the `WalletHistory` FK (no token fields duplicated on `WalletActivity`).
- PR #484 is already merged, so `0129` shipped with `amount`; this branch adds `0130` to drop it.

## Testing

- Syntax-verified locally. Django env/db are remote, so confirm `makemigrations --check` / `migrate` and the backfill on the server:
  ```bash
  python manage.py migrate main
  python manage.py backfill_wallet_activity --dry-run
  ```