### PR TITLE
Add wallet activity report endpoint

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -92,6 +92,11 @@ main_urls += [
         name="growth-report",
     ),
     re_path(
+        r"^reports/wallet_activity/$",
+        views.WalletActivityReportView.as_view(),
+        name="wallet-activity-report",
+    ),
+    re_path(
         r"^task/(?P<task_id>[\w+:-]+)/$",
         views.TaskStatusView.as_view(),
         name="task-status",

--- a/main/views/__init__.py
+++ b/main/views/__init__.py
@@ -32,3 +32,4 @@ from main.views.view_asset_setting import *
 from main.views.view_address_book import *
 from main.views.view_wallet_history_explorer import *
 from main.views.view_growth_report import *
+from main.views.view_wallet_activity_report import *

--- a/main/views/view_wallet_activity_report.py
+++ b/main/views/view_wallet_activity_report.py
@@ -1,0 +1,117 @@
+from datetime import datetime
+
+from django.core.paginator import Paginator
+from django.utils import timezone
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import status as http_status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from main.models import WalletActivity
+
+
+def _parse_date(date_str):
+    if date_str:
+        try:
+            return datetime.strptime(date_str, "%Y-%m-%d").date()
+        except (ValueError, TypeError):
+            return None
+    return timezone.now().date()
+
+
+class WalletActivityReportView(APIView):
+    """Return per-event WalletActivity rows for a specific UTC day.
+
+    Each event carries the WalletActivity record id as ``event_id``,
+    together with the wallet hash, activity date, kind, and (for
+    transaction events) the on-chain txid and amount in satoshis.
+    """
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                name="date",
+                type=openapi.TYPE_STRING,
+                in_=openapi.IN_QUERY,
+                description="UTC day in YYYY-MM-DD format. Defaults to today (UTC).",
+            ),
+            openapi.Parameter(
+                name="page",
+                type=openapi.TYPE_NUMBER,
+                in_=openapi.IN_QUERY,
+                default=1,
+            ),
+            openapi.Parameter(
+                name="page_size",
+                type=openapi.TYPE_NUMBER,
+                in_=openapi.IN_QUERY,
+                default=100,
+            ),
+        ],
+    )
+    def get(self, request, *args, **kwargs):
+        date_str = request.query_params.get("date")
+        page = request.query_params.get("page", 1)
+        page_size = request.query_params.get("page_size", 100)
+
+        try:
+            page = int(page)
+            page_size = int(page_size)
+        except (ValueError, TypeError):
+            return Response(
+                {"error": "page and page_size must be integers."},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+        if page < 1 or page_size < 1:
+            return Response(
+                {"error": "page and page_size must be positive integers."},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+
+        report_date = _parse_date(date_str)
+        if report_date is None:
+            return Response(
+                {"error": "Invalid date format. Use YYYY-MM-DD."},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+
+        activities = WalletActivity.objects.filter(
+            activity_date=report_date,
+        ).select_related("wallet", "history").order_by("-date_created", "-id")
+
+        pages = Paginator(activities, page_size)
+        try:
+            page_obj = pages.page(page)
+        except Exception:
+            return Response(
+                {"error": "Page out of range."},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
+
+        events = []
+        for activity in page_obj.object_list:
+            history = activity.history
+            amount = None
+            txid = None
+            if history is not None:
+                if history.amount is not None:
+                    amount = int(history.amount * 100_000_000)
+                txid = history.txid
+            events.append({
+                "event_id": str(activity.id),
+                "wallet_hash": activity.wallet.wallet_hash,
+                "activity_date": activity.activity_date.isoformat(),
+                "kind": activity.kind,
+                "txid": txid,
+                "amount": amount,
+            })
+
+        return Response({
+            "results": events,
+            "count": pages.count,
+            "page": page,
+            "page_size": page_size,
+            "num_pages": pages.num_pages,
+            "has_next": page_obj.has_next(),
+        })

--- a/main/views/view_wallet_activity_report.py
+++ b/main/views/view_wallet_activity_report.py
@@ -1,3 +1,4 @@
+import hashlib
 from datetime import datetime
 
 from django.core.paginator import Paginator
@@ -24,8 +25,9 @@ class WalletActivityReportView(APIView):
     """Return per-event WalletActivity rows for a specific UTC day.
 
     Each event carries the WalletActivity record id as ``event_id``,
-    together with the wallet hash, activity date, kind, and (for
-    transaction events) the on-chain txid and amount in satoshis.
+    together with a wallet digest (sha256 of the wallet hash), the
+    activity date, kind, and (for transaction events) the on-chain
+    txid and amount in satoshis.
     """
 
     @swagger_auto_schema(
@@ -100,7 +102,9 @@ class WalletActivityReportView(APIView):
                 txid = history.txid
             events.append({
                 "event_id": str(activity.id),
-                "wallet_hash": activity.wallet.wallet_hash,
+                "wallet_digest": hashlib.sha256(
+                    activity.wallet.wallet_hash.encode()
+                ).hexdigest(),
                 "activity_date": activity.activity_date.isoformat(),
                 "kind": activity.kind,
                 "txid": txid,

--- a/main/views/view_wallet_activity_report.py
+++ b/main/views/view_wallet_activity_report.py
@@ -1,7 +1,7 @@
 import hashlib
 from datetime import datetime
 
-from django.core.paginator import Paginator
+from django.core.paginator import EmptyPage, Paginator
 from django.utils import timezone
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
@@ -70,6 +70,7 @@ class WalletActivityReportView(APIView):
                 {"error": "page and page_size must be positive integers."},
                 status=http_status.HTTP_400_BAD_REQUEST,
             )
+        page_size = min(page_size, 1000)
 
         report_date = _parse_date(date_str)
         if report_date is None:
@@ -85,7 +86,7 @@ class WalletActivityReportView(APIView):
         pages = Paginator(activities, page_size)
         try:
             page_obj = pages.page(page)
-        except Exception:
+        except EmptyPage:
             return Response(
                 {"error": "Page out of range."},
                 status=http_status.HTTP_400_BAD_REQUEST,
@@ -98,7 +99,7 @@ class WalletActivityReportView(APIView):
             txid = None
             if history is not None:
                 if history.amount is not None:
-                    amount = int(history.amount * 100_000_000)
+                    amount = int(round(history.amount * 100_000_000))
                 txid = history.txid
             events.append({
                 "event_id": str(activity.id),

--- a/tests/test_wallet_activity_report.py
+++ b/tests/test_wallet_activity_report.py
@@ -1,0 +1,135 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from main.models import Project, Token, Wallet, WalletActivity, WalletHistory
+
+
+def _utc_date_str(dt):
+    return dt.strftime("%Y-%m-%d")
+
+
+class WalletActivityReportViewTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.project = Project.objects.create(name="paytaca")
+        self.bch_token = Token.objects.create(
+            name="bch",
+            tokenid="",
+            token_ticker="BCH",
+        )
+        self.wallet_a = Wallet.objects.create(
+            wallet_hash="wallet_a_hash",
+            wallet_type="bch",
+            version=2,
+            project=self.project,
+        )
+        self.wallet_b = Wallet.objects.create(
+            wallet_hash="wallet_b_hash",
+            wallet_type="bch",
+            version=2,
+            project=self.project,
+        )
+        self.url = reverse("wallet-activity-report")
+        self.today = timezone.now().date()
+        self.date_str = _utc_date_str(timezone.now())
+
+    def _create_history(self, **kwargs):
+        defaults = {
+            "wallet": self.wallet_a,
+            "txid": "txid_%s" % (WalletHistory.objects.count() + 1),
+            "record_type": WalletHistory.OUTGOING,
+            "amount": 1.0,
+            "token": self.bch_token,
+            "tx_timestamp": timezone.now(),
+        }
+        defaults.update(kwargs)
+        return WalletHistory.objects.create(**defaults)
+
+    def _create_activity(self, history=None, kind=None, wallet=None, day=None):
+        return WalletActivity.objects.create(
+            wallet=wallet or self.wallet_a,
+            history=history,
+            kind=kind or WalletActivity.KIND_TRANSACTION_SEND,
+            activity_date=day or self.today,
+        )
+
+    def test_empty_day_returns_empty_results(self):
+        response = self.client.get(self.url, {"date": "2020-01-01"})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["results"], [])
+        self.assertEqual(data["count"], 0)
+        self.assertFalse(data["has_next"])
+
+    def test_event_id_is_wallet_activity_id_not_txid(self):
+        history = self._create_history(txid="abc123")
+        activity = self._create_activity(history=history)
+        response = self.client.get(self.url, {"date": self.date_str})
+        data = response.json()
+        self.assertEqual(len(data["results"]), 1)
+        entry = data["results"][0]
+        self.assertEqual(entry["event_id"], str(activity.id))
+        self.assertNotEqual(entry["event_id"], "abc123")
+
+    def test_transaction_send_returns_txid_and_sats_amount(self):
+        history = self._create_history(txid="send_txid", amount=1.0)
+        self._create_activity(history=history, kind=WalletActivity.KIND_TRANSACTION_SEND)
+        response = self.client.get(self.url, {"date": self.date_str})
+        entry = response.json()["results"][0]
+        self.assertEqual(entry["kind"], WalletActivity.KIND_TRANSACTION_SEND)
+        self.assertEqual(entry["txid"], "send_txid")
+        self.assertEqual(entry["amount"], 100_000_000)
+
+    def test_app_opening_has_null_txid_and_amount(self):
+        self._create_activity(kind=WalletActivity.KIND_APP_OPENING)
+        response = self.client.get(self.url, {"date": self.date_str})
+        entry = response.json()["results"][0]
+        self.assertEqual(entry["kind"], WalletActivity.KIND_APP_OPENING)
+        self.assertIsNone(entry["txid"])
+        self.assertIsNone(entry["amount"])
+
+    def test_activity_outside_date_excluded(self):
+        old_day = self.today.replace(year=self.today.year - 1)
+        history = self._create_history(txid="old_txid")
+        self._create_activity(history=history, day=old_day)
+        response = self.client.get(self.url, {"date": self.date_str})
+        self.assertEqual(response.json()["count"], 0)
+
+    def test_pagination(self):
+        for i in range(5):
+            history = self._create_history(txid="tx_%d" % i)
+            self._create_activity(history=history)
+        response = self.client.get(
+            self.url, {"date": self.date_str, "page_size": 2, "page": 1}
+        )
+        data = response.json()
+        self.assertEqual(len(data["results"]), 2)
+        self.assertEqual(data["count"], 5)
+        self.assertEqual(data["num_pages"], 3)
+        self.assertTrue(data["has_next"])
+
+        response = self.client.get(
+            self.url, {"date": self.date_str, "page_size": 2, "page": 3}
+        )
+        data = response.json()
+        self.assertEqual(len(data["results"]), 1)
+        self.assertFalse(data["has_next"])
+
+    def test_page_out_of_range_returns_400(self):
+        self._create_activity()
+        response = self.client.get(
+            self.url, {"date": self.date_str, "page": 999}
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_invalid_date_returns_400(self):
+        response = self.client.get(self.url, {"date": "not-a-date"})
+        self.assertEqual(response.status_code, 400)
+
+    def test_non_integer_pagination_returns_400(self):
+        response = self.client.get(
+            self.url, {"date": self.date_str, "page_size": "abc"}
+        )
+        self.assertEqual(response.status_code, 400)

--- a/tests/test_wallet_activity_report.py
+++ b/tests/test_wallet_activity_report.py
@@ -5,6 +5,8 @@ from rest_framework.test import APIClient
 
 from main.models import Project, Token, Wallet, WalletActivity, WalletHistory
 
+import hashlib
+
 
 def _utc_date_str(dt):
     return dt.strftime("%Y-%m-%d")
@@ -72,6 +74,15 @@ class WalletActivityReportViewTestCase(TestCase):
         entry = data["results"][0]
         self.assertEqual(entry["event_id"], str(activity.id))
         self.assertNotEqual(entry["event_id"], "abc123")
+
+    def test_returns_wallet_digest_not_raw_wallet_hash(self):
+        history = self._create_history(txid="digest_txid")
+        self._create_activity(history=history)
+        response = self.client.get(self.url, {"date": self.date_str})
+        entry = response.json()["results"][0]
+        expected = hashlib.sha256(self.wallet_a.wallet_hash.encode()).hexdigest()
+        self.assertEqual(entry["wallet_digest"], expected)
+        self.assertNotIn("wallet_hash", entry)
 
     def test_transaction_send_returns_txid_and_sats_amount(self):
         history = self._create_history(txid="send_txid", amount=1.0)

--- a/tests/test_wallet_activity_report.py
+++ b/tests/test_wallet_activity_report.py
@@ -101,6 +101,21 @@ class WalletActivityReportViewTestCase(TestCase):
         self.assertIsNone(entry["txid"])
         self.assertIsNone(entry["amount"])
 
+    def test_transaction_receive_returns_txid_and_sats_amount(self):
+        history = self._create_history(
+            txid="recv_txid",
+            amount=1.0,
+            record_type=WalletHistory.INCOMING,
+        )
+        self._create_activity(
+            history=history, kind=WalletActivity.KIND_TRANSACTION_RECEIVE
+        )
+        response = self.client.get(self.url, {"date": self.date_str})
+        entry = response.json()["results"][0]
+        self.assertEqual(entry["kind"], WalletActivity.KIND_TRANSACTION_RECEIVE)
+        self.assertEqual(entry["txid"], "recv_txid")
+        self.assertEqual(entry["amount"], 100_000_000)
+
     def test_activity_outside_date_excluded(self):
         old_day = self.today.replace(year=self.today.year - 1)
         history = self._create_history(txid="old_txid")


### PR DESCRIPTION
## Summary

Adds the `/api/reports/wallet_activity/` endpoint so the growth-tracker application can fetch per-event wallet activity via its `fetch_wallet_activity` management command. Previously this URL returned a 404 — the `WalletActivity` model, migration, backfill command, and signal hook existed, but no API view/URL had been wired up.

## Changes

- **`main/views/view_wallet_activity_report.py`** (new): `WalletActivityReportView`
  - Query params: `date` (UTC `YYYY-MM-DD`, defaults to today), `page`, `page_size`
  - Paginated response: `{results, count, page, page_size, num_pages, has_next}`, matching the growth-tracker client contract (`results` / `has_next`)
  - Each event:
    - `event_id` — the WalletActivity **record id** (not the txid)
    - `wallet_digest` — sha256 of the wallet hash (raw wallet_hash is not exposed)
    - `activity_date`, `kind`, `txid`
    - `amount` in satoshis (from `history.amount * 100_000_000`)
  - No kind filter — all kinds (`transaction-send`, `transaction-receive`, `app-opening`) are returned; the client filters
- **`main/urls.py`**: registered `reports/wallet_activity/` (`name="wallet-activity-report"`)
- **`main/views/__init__.py`**: exported the new view
- **`tests/test_wallet_activity_report.py`** (new): covers event_id as record id, wallet_digest derivation, txid/amount for sends, null txid/amount for app-opening, date filtering, pagination, and invalid-parameter 400s

## Companion change

The growth-tracker fetch command was updated to read `wallet_digest` from the response instead of `wallet_hash`.

## Verification

- `python -m py_compile` passes on new files
- Tests run on the remote server (required Postgres/Redis env not available locally)